### PR TITLE
[FIX] Корректное включение операции после паузы

### DIFF
--- a/PAC/common/mode_mngr.cpp
+++ b/PAC/common/mode_mngr.cpp
@@ -114,6 +114,7 @@ int operation::start()
             break;
 
         case PAUSE:
+            states[ PAUSE ]->final();
             states[ RUN ]->load();
 
             current_state = RUN;


### PR DESCRIPTION
Если в паузе было прописано включение устройств, то теперь они выключаются при возобновлении операции.