### PR TITLE
Exclude sonar analysis from PR

### DIFF
--- a/.github/workflows/sonar_build.yml
+++ b/.github/workflows/sonar_build.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, synchronize, reopened]
   schedule:
     - cron: '0 9 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
SonarCloud can't analyze external Pull Request from fork now. Explanation here - https://community.sonarsource.com/t/how-to-use-sonarcloud-with-a-forked-repository-on-github/7363/2.