### PR TITLE
Fix a bug with access to devices when initializing objects

### DIFF
--- a/PAC/common/PAC_dev.cpp
+++ b/PAC/common/PAC_dev.cpp
@@ -18,6 +18,12 @@ std::vector<valve_DO2_DI2_bistable*> valve::v_bistable;
 
 std::vector<valve_bottom_mix_proof*> valve_bottom_mix_proof::to_switch_off;
 
+valve_iolink_mix_proof::out_data_swapped valve_iolink_mix_proof::stub_out_info;
+valve_iolink_shut_off_thinktop::out_data_swapped valve_iolink_shut_off_thinktop::stub_out_info;
+circuit_breaker::F_data_out circuit_breaker::stub_out_info;
+analog_valve_iolink::out_data analog_valve_iolink::stub_out_info;
+signal_column_iolink::out_data signal_column_iolink::stub_out_info;
+
 const char* const device::DEV_NAMES[ device::DEVICE_TYPE::C_DEVICE_TYPE_CNT ] =
     {
     "V",       ///< Клапан.
@@ -4190,16 +4196,16 @@ void valve_iolink_shut_off_thinktop::direct_set_state( int new_state )
 #endif // DEBUG_NO_IO_MODULES
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-valve_iolink_vtug::valve_iolink_vtug( const char *dev_name,
+valve_iolink_vtug::valve_iolink_vtug( const char* dev_name,
     device::DEVICE_SUB_TYPE sub_type ) : valve( dev_name, DT_V, sub_type ),
     vtug_number( 0 )
     {
     }
 //-----------------------------------------------------------------------------
-valve_iolink_vtug::valve_iolink_vtug(bool is_on_fb, bool is_off_fb,
-    const char* dev_name, device::DEVICE_SUB_TYPE sub_type) :
-    valve(is_on_fb, is_off_fb, dev_name, DT_V, sub_type),
-    vtug_number(0)
+valve_iolink_vtug::valve_iolink_vtug( bool is_on_fb, bool is_off_fb,
+    const char* dev_name, device::DEVICE_SUB_TYPE sub_type ) :
+    valve( is_on_fb, is_off_fb, dev_name, DT_V, sub_type ),
+    vtug_number( 0 )
     {
     }
 //-----------------------------------------------------------------------------
@@ -4232,6 +4238,11 @@ void valve_iolink_vtug::direct_on()
         start_switch_time = get_millisec();
         }
 
+    if ( !data || !vtug_number )
+        {
+        return;
+        }
+
     u_int offset = ( vtug_number - 1 ) / 8;
     data[ offset ] |= 1 << ( ( vtug_number - 1 ) % 8 );
     }
@@ -4246,27 +4257,31 @@ void valve_iolink_vtug::direct_off()
         start_switch_time = get_millisec();
         }
 
+    if ( !data || !vtug_number )
+        {
+        return;
+        }
+
     u_int offset = ( vtug_number - 1 ) / 8;
     data[ offset ] &= ~( 1 << ( ( vtug_number - 1 ) % 8 ) );
     }
-
-
+//-----------------------------------------------------------------------------
 int valve_iolink_vtug::get_state()
-	{
-	if (get_AO_IOLINK_state(0) != io_device::IOLINKSTATE::OK)
-		{
-		return -1;
-		}
-	else
-		{
-		return valve::get_state();
-		}
-	}
+    {
+    if ( get_AO_IOLINK_state( 0 ) != io_device::IOLINKSTATE::OK )
+        {
+        return -1;
+        }
+    else
+        {
+        return valve::get_state();
+        }
+    }
 #endif // DEBUG_NO_IO_MODULES
 //-----------------------------------------------------------------------------
 char valve_iolink_vtug::get_state_data( char* data )
     {
-    if ( data == 0 )
+    if ( !data || !vtug_number )
         {
         return 0;
         }

--- a/PAC/common/PAC_dev.h
+++ b/PAC/common/PAC_dev.h
@@ -2247,7 +2247,8 @@ class valve_iolink_mix_proof : public i_mix_proof,  public valve
             };
 
         in_data*  in_info = new in_data;
-        out_data_swapped* out_info;
+        static out_data_swapped stub_out_info;
+        out_data_swapped* out_info = &stub_out_info;
 
         bool blink = false;     //Visual indication
 
@@ -2319,7 +2320,8 @@ class valve_iolink_shut_off_thinktop : public valve
             };
 
         in_data* in_info = new in_data;
-        out_data_swapped* out_info = 0;
+        static out_data_swapped stub_out_info;
+        out_data_swapped* out_info = &stub_out_info;
 
         bool blink = false;     //Visual indication
 
@@ -2939,7 +2941,8 @@ class circuit_breaker : public analog_io_device
         int m;
 
         F_data_in in_info;
-        F_data_out* out_info;
+        static F_data_out stub_out_info;
+        F_data_out* out_info = &stub_out_info;
     };
 //-----------------------------------------------------------------------------
 /// @brief Датчик сигнализатора уровня IO-Link.
@@ -3451,7 +3454,8 @@ class analog_valve_iolink : public AO1
 #pragma pack(pop)
 
         in_data* in_info = new in_data;
-        out_data* out_info;
+        static out_data stub_out_info;
+        out_data* out_info = &stub_out_info;
 
         bool blink = false;     //Visual indication
     };
@@ -4241,7 +4245,8 @@ class signal_column_iolink : public signal_column
             uint16_t unused2 : 3;
             };
 
-        out_data *out_info;
+        static out_data stub_out_info;
+        out_data *out_info = &stub_out_info;
     };
 //-----------------------------------------------------------------------------
 /// @brief Камера.

--- a/PAC/common/param_ex.cpp
+++ b/PAC/common/param_ex.cpp
@@ -94,8 +94,6 @@ void params_manager::final_init( int auto_init_params /*= 1*/,
             100. * last_idx / C_TOTAL_PARAMS_SIZE, '%' );
     G_LOG->write_log( i_log::P_DEBUG );
 
-    G_DEVICE_MANAGER()->init_rt_params();
-
     //Проверка на изменение количества параметров.
     unsigned char buff[ 4 ] = { 0 };
     CRC_mem->read( ( char* ) buff, 4, C_LAST_IDX_OFFSET );

--- a/common/lua_manager.cpp
+++ b/common/lua_manager.cpp
@@ -272,6 +272,11 @@ int lua_manager::init( lua_State* lua_state, const char* script_name,
         return res;
         }
 
+    //Инициализация параметров для корректной работы устройств.
+    G_DEVICE_MANAGER()->init_rt_params();
+    //Получение данных из модулей ввода\вывода для корректной работы устройств.
+    G_DEVICE_MANAGER()->evaluate_io();
+
     //IV Выполнение основного скрипта ('main.plua').
     if ( G_DEBUG )
         {


### PR DESCRIPTION
There was a problem with switching on operations  when initializing objects (in Lua function "object:init()").