### PR TITLE
Use number instead of numerical constant

### DIFF
--- a/PAC/linux/PAC_PLCnext/PtusaPLCnextEngineer/PtusaMainPrg.hpp
+++ b/PAC/linux/PAC_PLCnext/PtusaPLCnextEngineer/PtusaMainPrg.hpp
@@ -15,7 +15,7 @@ namespace PtusaPLCnextEngineer
     class PtusaMainPrg: public ProgramBase, private Loggable<PtusaMainPrg>
         {
     public:
-        // typedefs
+        // typedefs        
 
     public:
         // construction/destruction
@@ -30,7 +30,6 @@ namespace PtusaPLCnextEngineer
 
     public:
         // properties
-        static const int MAX_NVRAM_SIZE = 49000;
 
     public:
         // operations
@@ -38,11 +37,11 @@ namespace PtusaPLCnextEngineer
 
         //#port
         //#attributes(Output|Retain)
-        uint8 NVRAM[ MAX_NVRAM_SIZE ] = {0};
+        uint8 NVRAM[ 49000 ] = {0};
 
     private:
         // fields
-        PtusaPLCnextEngineer::PtusaMainCmpnt& ptusaMainCmpnt;
+        PtusaPLCnextEngineer::PtusaMainCmpnt& ptusaMainCmpnt;       
         };
 
     ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Use number to get correct generation in PLCnCLI 2022.