### PR TITLE
[config][github actions] Update build workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -111,7 +111,7 @@ jobs:
       shell: cmake -P {0}
       run: |
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
+        file( APPEND "$ENV{GITHUB_OUTPUT}" "timestamp=${current_date}" )
 
     - name: ccache cache files
       uses: actions/cache@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -111,7 +111,7 @@ jobs:
       shell: cmake -P {0}
       run: |
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        file( APPEND "$ENV{GITHUB_OUTPUT}" "timestamp=${current_date}" )
+        file(APPEND "$ENV{GITHUB_OUTPUT}" "timestamp=${current_date}\n")
 
     - name: ccache cache files
       uses: actions/cache@v3


### PR DESCRIPTION
Remove deprecated functionality (https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) - migrating from `::set-output` to environment files (`GITHUB_OUTPUT` environment variable).