### PR TITLE
[config][github actions] Remove event "merge_group"

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,6 @@ on:
       - '**/*.md'
   schedule:
     - cron: '0 9 * * 1'
-  merge_group:
 
 jobs:
   analyze:


### PR DESCRIPTION
Check on event "merge_group" is not necessary during merge queue processing.