### PR TITLE
[test] Fix OPC UA

### DIFF
--- a/test/PAC_info_tests.cpp
+++ b/test/PAC_info_tests.cpp
@@ -6,12 +6,13 @@ using namespace ::testing;
 TEST( PAC_info, set_cmd )
     {
     G_PAC_INFO()->set_cmd( "CMD", 0, PAC_info::RELOAD_RESTRICTIONS );
-
+#ifdef OPCUA
     EXPECT_EQ( 0, G_PAC_INFO()->par[ PAC_info::P_IS_OPC_UA_SERVER_ACTIVE ] );
     G_PAC_INFO()->set_cmd( "P_IS_OPC_UA_SERVER_ACTIVE", 0, 1 );
     EXPECT_EQ( 1, G_PAC_INFO()->par[ PAC_info::P_IS_OPC_UA_SERVER_ACTIVE ] );
     G_PAC_INFO()->set_cmd( "P_IS_OPC_UA_SERVER_ACTIVE", 0, 0 );
     EXPECT_EQ( 0, G_PAC_INFO()->par[ PAC_info::P_IS_OPC_UA_SERVER_ACTIVE ] );
+#endif
     }
 
 TEST( PAC_info, reset_params )


### PR DESCRIPTION
Добавлена директива препроцессора `#ifdef` для теста **OPC UA**. Теперь все тесты **OPC UA** сервера выполняются в зависимости от параметра сборки `USE_OPCUA`.