### PR TITLE
[config][cmake] Install penlight 1.13 manually

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -253,7 +253,7 @@ jobs:
       shell: cmd
       run: |
         call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
-        luarocks install penlight 1.13
+        luarocks install penlight 1.13.1-1
         luarocks install busted
 
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -253,6 +253,7 @@ jobs:
       shell: cmd
       run: |
         call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        luarocks install penlight 1.13
         luarocks install busted
 
 


### PR DESCRIPTION
The current latest version of Penlight 1.14.0-1 requires the LuaRocks version >= 3.0, we are installing 2.4 - so this is a temporary solution. It is best to install LuaRocks version >= 3.0 - this should be done later.