### PR TITLE
[config][github-actions] Fix warning from Sonar

### DIFF
--- a/.github/workflows/sonar_build.yml
+++ b/.github/workflows/sonar_build.yml
@@ -87,4 +87,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          sonar-scanner --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" --define sonar.pullrequest.key=${{ github.event.pull_request.number }} --define sonar.scm.revision=${{ github.event.pull_request.head.sha }}
+          sonar-scanner --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json" --define sonar.pullrequest.key=${{ github.event.pull_request.number }} --define sonar.scm.revision=${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Fix the following warning:

>     Property 'sonar.cfamily.build-wrapper-output' is deprecated; build-wrapper now generates a compilation database.
>     Please use the property 'sonar.cfamily.compile-commands' instead to specify the path of the 'compile_commands.json' file generated inside the build-wrapper output directory.
>     Visit the documentation for more up-to-date information on analysis using build-wrapper https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/overview/
