### PR TITLE
Fix error: ‘put_time’ is not a member of ‘std’

### DIFF
--- a/test/prj_mngr_tests.cpp
+++ b/test/prj_mngr_tests.cpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <iomanip>
 
 #include "prj_mngr_tests.h"
 #include "lua_manager.h"


### PR DESCRIPTION
Connected with #738.