### PR TITLE
Revert "Bump deps/open62541/open62541 from v1.4.6 to v1.4.11"

### DIFF
--- a/CTestCustom.cmake
+++ b/CTestCustom.cmake
@@ -5,7 +5,7 @@ file(WRITE "@CMAKE_BINARY_DIR@/CTestTestfile.cmake" "")
 
 # loop through the lines,
 foreach(LINE IN LISTS LINES)
-  if(NOT "${LINE}" MATCHES [[subdirs\(\"deps/lua/lua\"\)|subdirs\(\"deps/zlib/zlib\"\)|subdirs\(\"deps/toluapp/toluapp\"\)|subdirs\(\"deps/benchmark\"\)]] )
+  if(NOT "${LINE}" MATCHES [[subdirs\(\"deps/lua\"\)|subdirs\(\"deps/zlib\"\)|subdirs\(\"deps/toluapp\"\)|subdirs\(\"deps/benchmark\"\)]] )
     # write line without unwanted parts ...
     file(APPEND "@CMAKE_BINARY_DIR@/CTestTestfile.cmake" "${LINE}\n")
   endif()


### PR DESCRIPTION
Reverts savushkin-r-d/ptusa_main#893.  [CTestCustom.cmake](https://github.com/savushkin-r-d/ptusa_main/compare/master...revert-893-dependabot/submodules/deps/open62541/open62541-cae846b?expand=1#diff-94be3472c6b6bbfbb90c975faebdfc0e67f9ee55a2cf05a033c300af08498512) не должен здесь изменяться.