### PR TITLE
Fixes missing break statement

### DIFF
--- a/PAC/common/modbus_serv.cpp
+++ b/PAC/common/modbus_serv.cpp
@@ -940,6 +940,7 @@ long ModbusServ::ModbusService( long len, unsigned char *data,unsigned char *out
 											confirmPrgUpdateCtr[line] = 0;
 											}
 										}
+									break;
 								default:
 									if (objnumber >= RC_RECIPE_PAR_START)
 										{


### PR DESCRIPTION
Adds a missing `break` statement in a switch case within the Modbus service logic. This prevents fallthrough to the default case when handling a specific condition.
