### PR TITLE
Adds support for new IFM LMT sensors

### DIFF
--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -2706,6 +2706,17 @@ void level_s_iolink::set_article( const char* new_article )
         n_article = ARTICLE::IFM_LMT105;
         return;
         }
+    if ( strcmp( article, "IFM.LMT121" ) == 0 )
+        {
+        n_article = ARTICLE::IFM_LMT121;
+        return;
+        }
+    if ( strcmp( article, "IFM.LMT202" ) == 0 )
+        {
+        n_article = ARTICLE::IFM_LMT202;
+        return;
+        }
+
     if ( strcmp( article, "E&H.FTL33-GR7N2ABW5J" ) == 0 )
         {
         n_article = ARTICLE::EH_FTL33;
@@ -2718,6 +2729,13 @@ void level_s_iolink::set_article( const char* new_article )
             get_name(), new_article );
         }
     }
+
+#ifdef PTUSA_TEST
+level_s_iolink::ARTICLE level_s_iolink::get_article_n() const
+    {
+    return n_article;
+    }
+#endif
 
 float level_s_iolink::get_value()
     {

--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -2655,6 +2655,8 @@ void level_s_iolink::evaluate_io()
         case ARTICLE::IFM_LMT102:   //IFM.LMT102
         case ARTICLE::IFM_LMT104:   //IFM.LMT104
         case ARTICLE::IFM_LMT105:   //IFM.LMT105
+        case ARTICLE::IFM_LMT121:   //IFM.LMT121
+        case ARTICLE::IFM_LMT202:   //IFM.LMT202
             {
             LS_data info{};
             std::reverse_copy( data, data + sizeof( info ), (char*)&info );

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -982,7 +982,10 @@ class level_s_iolink : public analog_io_device
 
         void set_article( const char* new_article ) override;
 
+#ifndef PTUSA_TEST
     private:
+#endif
+
         int current_state;
         u_int_4 time = get_millisec();
 
@@ -1000,6 +1003,10 @@ class level_s_iolink : public analog_io_device
             };
         ARTICLE n_article = ARTICLE::DEFAULT;
 
+#ifdef PTUSA_TEST
+        ARTICLE get_article_n() const;
+#endif
+
         struct LS_data
             {
             uint16_t st1 :1;
@@ -1016,7 +1023,6 @@ class level_s_iolink : public analog_io_device
         float v = .0f;
         int st = 0;
 
-    private:
         enum CONSTANTS
             {
             C_AI_INDEX = 0,     ///< Индекс канала аналогового входа.

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -993,6 +993,8 @@ class level_s_iolink : public analog_io_device
             IFM_LMT102,
             IFM_LMT104,
             IFM_LMT105,
+            IFM_LMT121,
+            IFM_LMT202,
 
             EH_FTL33,
             };

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -989,7 +989,7 @@ class level_s_iolink : public analog_io_device
         int current_state;
         u_int_4 time = get_millisec();
 
-        enum ARTICLE
+        enum class ARTICLE
             {
             DEFAULT,
             IFM_LMT100,

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -2886,16 +2886,18 @@ class LevelSIOLinkTest : public ::testing::Test
     protected:
         level_s_iolink* device;
 
-        void SetUp() override {
+        void SetUp() override
+            {
             device = new level_s_iolink( "TestDevice", device::LS_IOLINK_MAX );
             }
 
-        void TearDown() override {
+        void TearDown() override
+            {
             delete device;
             }
     };
 
-TEST_F( LevelSIOLinkTest, SetArticle_ValidArticles ) 
+TEST_F( LevelSIOLinkTest, SetArticle_ValidArticles )
     {
     struct TestCase
         {
@@ -2903,7 +2905,8 @@ TEST_F( LevelSIOLinkTest, SetArticle_ValidArticles )
         level_s_iolink::ARTICLE expected;
         };
 
-    std::array<TestCase, 7> testCases = { {
+    std::array<TestCase, 7> testCases =
+        { {
         {"IFM.LMT100", level_s_iolink::ARTICLE::IFM_LMT100},
         {"IFM.LMT102", level_s_iolink::ARTICLE::IFM_LMT102},
         {"IFM.LMT104", level_s_iolink::ARTICLE::IFM_LMT104},
@@ -2911,9 +2914,9 @@ TEST_F( LevelSIOLinkTest, SetArticle_ValidArticles )
         {"IFM.LMT121", level_s_iolink::ARTICLE::IFM_LMT121},
         {"IFM.LMT202", level_s_iolink::ARTICLE::IFM_LMT202},
         {"E&H.FTL33-GR7N2ABW5J", level_s_iolink::ARTICLE::EH_FTL33},
-    } };
+        } };
 
-    for ( const auto& testCase : testCases ) 
+    for ( const auto& testCase : testCases )
         {
         device->set_article( testCase.article );
         EXPECT_EQ( device->get_article_n(), testCase.expected )
@@ -2921,7 +2924,7 @@ TEST_F( LevelSIOLinkTest, SetArticle_ValidArticles )
         }
     }
 
-TEST_F( LevelSIOLinkTest, SetArticle_UnknownArticle ) 
+TEST_F( LevelSIOLinkTest, SetArticle_UnknownArticle )
     {
     const char* unknownArticle = "UNKNOWN.ARTICLE";
     device->set_article( unknownArticle );
@@ -2945,7 +2948,7 @@ TEST_F( LevelSIOLinkTest, get_state )
 
     G_PAC_INFO()->emulation_off();
     EXPECT_EQ( device->get_state(), 0 );
-    
+
     G_PAC_INFO()->emulation_on();
     }
 

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -2881,24 +2881,71 @@ TEST( level_s, get_type_name )
     }
 
 
-TEST( level_s_iolink, set_article )
+class LevelSIOLinkTest : public ::testing::Test
     {
-    level_s_iolink LS1( "LS1", device::LS_IOLINK_MAX );
-    LS1.set_article( "IFM.LMT100" );
-    EXPECT_EQ( false, LS1.is_active() );
+    protected:
+        level_s_iolink* device;
+
+        void SetUp() override {
+            device = new level_s_iolink( "TestDevice", device::LS_IOLINK_MAX );
+            }
+
+        void TearDown() override {
+            delete device;
+            }
+    };
+
+TEST_F( LevelSIOLinkTest, SetArticle_ValidArticles ) 
+    {
+    struct TestCase
+        {
+        const char* article;
+        level_s_iolink::ARTICLE expected;
+        };
+
+    std::array<TestCase, 7> testCases = { {
+        {"IFM.LMT100", level_s_iolink::ARTICLE::IFM_LMT100},
+        {"IFM.LMT102", level_s_iolink::ARTICLE::IFM_LMT102},
+        {"IFM.LMT104", level_s_iolink::ARTICLE::IFM_LMT104},
+        {"IFM.LMT105", level_s_iolink::ARTICLE::IFM_LMT105},
+        {"IFM.LMT121", level_s_iolink::ARTICLE::IFM_LMT121},
+        {"IFM.LMT202", level_s_iolink::ARTICLE::IFM_LMT202},
+        {"E&H.FTL33-GR7N2ABW5J", level_s_iolink::ARTICLE::EH_FTL33},
+    } };
+
+    for ( const auto& testCase : testCases ) 
+        {
+        device->set_article( testCase.article );
+        EXPECT_EQ( device->get_article_n(), testCase.expected )
+            << "Failed for article: " << testCase.article;
+        }
     }
 
-TEST( level_s_iolink, get_state )
+TEST_F( LevelSIOLinkTest, SetArticle_UnknownArticle ) 
     {
-    level_s_iolink LS1( "LS1", device::LS_IOLINK_MAX );
+    const char* unknownArticle = "UNKNOWN.ARTICLE";
+    device->set_article( unknownArticle );
 
+    EXPECT_EQ( device->get_article_n(), level_s_iolink::ARTICLE::DEFAULT )
+        << "Failed for unknown article: " << unknownArticle;
+    }
 
-    EXPECT_EQ( LS1.get_state(), 0 );
+TEST_F( LevelSIOLinkTest, SetArticle_EmptyArticle )
+    {
+    const char* emptyArticle = "";
+    device->set_article( emptyArticle );
+
+    EXPECT_EQ( device->get_article_n(), level_s_iolink::ARTICLE::DEFAULT )
+        << "Failed for empty article.";
+    }
+
+TEST_F( LevelSIOLinkTest, get_state )
+    {
+    EXPECT_EQ( device->get_state(), 0 );
 
     G_PAC_INFO()->emulation_off();
-    EXPECT_EQ( LS1.get_state(), 0 );
-
-
+    EXPECT_EQ( device->get_state(), 0 );
+    
     G_PAC_INFO()->emulation_on();
     }
 

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -2884,17 +2884,9 @@ TEST( level_s, get_type_name )
 class LevelSIOLinkTest : public ::testing::Test
     {
     protected:
-        level_s_iolink* device;
-
-        void SetUp() override
-            {
-            device = new level_s_iolink( "TestDevice", device::LS_IOLINK_MAX );
-            }
-
-        void TearDown() override
-            {
-            delete device;
-            }
+        std::unique_ptr<level_s_iolink> device = 
+            std::make_unique<level_s_iolink>(
+            "TestDevice", device::LS_IOLINK_MAX );
     };
 
 TEST_F( LevelSIOLinkTest, SetArticle_ValidArticles )


### PR DESCRIPTION
Fixes #896.

Extends the device support to include IFM LMT121 and LMT202
sensors. This involves adding the new sensor types to the
enumeration and incorporating them into the data evaluation logic.
