### PR TITLE
Disables building shared libraries for toluapp

### DIFF
--- a/deps/toluapp/CMakeLists.txt
+++ b/deps/toluapp/CMakeLists.txt
@@ -2,4 +2,5 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
     set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 endif()
 
+set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(toluapp)


### PR DESCRIPTION
Forces toluapp to be built as a static library by default. This simplifies the build process and avoids potential issues with shared library dependencies.
