### PR TITLE
Compensates PID dt for large time deltas

### DIFF
--- a/PAC/common/PID.cpp
+++ b/PAC/common/PID.cpp
@@ -92,7 +92,7 @@ float PID::eval( float currentValue, int deltaSign )
             }
         }
 
-    float dt = ( *par )[ P_dt ] / MSEC_IN_SEC;
+    float dt = ( *par )[ P_dt ];
     float dmax = ( *par )[ P_max ];
     float dmin = ( *par )[ P_min ];
 
@@ -123,7 +123,7 @@ float PID::eval( float currentValue, int deltaSign )
     if ( dt == 0 ) dt = 1;
     if ( TI == 0 ) TI = 0.0001f;
 
-    if ( auto eval_dt = get_delta_millisec( last_time ); eval_dt > dt * MSEC_IN_SEC )
+    if ( auto eval_dt = get_delta_millisec( last_time ); eval_dt > dt )
         {
         dt = eval_dt / MSEC_IN_SEC;
         q0 = K * ( 1 + TD / dt );

--- a/PAC/common/PID.cpp
+++ b/PAC/common/PID.cpp
@@ -120,12 +120,13 @@ float PID::eval( float currentValue, int deltaSign )
             }
         }
 
-    if ( set_delta_ms == 0 ) set_delta_ms = 1'000;
+    if ( set_delta_ms == 0 ) set_delta_ms =
+        static_cast<float>( CONSTANTS::DEFAULT_DELTA_MS );
     if ( TI == 0 ) TI = 0.0001f;
 
     if ( auto actual_delta_ms = get_delta_millisec( last_time ); actual_delta_ms > set_delta_ms )
         {
-        float dt = static_cast<float> ( actual_delta_ms / MSEC_IN_SEC );
+        auto dt = static_cast<float>( actual_delta_ms / MSEC_IN_SEC );
         q0 = K * ( 1 + TD / dt );
         q1 = K * ( -1 - 2 * TD / dt + 2 * dt / TI );
         q2 = K * TD / dt;

--- a/PAC/common/PID.cpp
+++ b/PAC/common/PID.cpp
@@ -112,7 +112,7 @@ float PID::eval( float currentValue, int deltaSign )
         {
         if ( set_delta_ms == 0 )
             {
-            printf( "Error! PID::eval() - dt = 0!\n" );
+            printf( "Error! PID::eval() - set_delta_ms = 0!\n" );
             }
         if ( TI == 0 )
             {
@@ -160,7 +160,7 @@ float PID::eval( float currentValue, int deltaSign )
         //-Зона разгона.-!>
 
         last_time = get_millisec();
-        } // if ( get_millisec() - last_time > dt*1000L )
+        }
 
     //-Мягкий пуск.
     // Включили ручной режим.

--- a/PAC/common/PID.cpp
+++ b/PAC/common/PID.cpp
@@ -125,7 +125,7 @@ float PID::eval( float currentValue, int deltaSign )
 
     if ( auto actual_delta_ms = get_delta_millisec( last_time ); actual_delta_ms > set_delta_ms )
         {
-        auto dt = actual_delta_ms / MSEC_IN_SEC;
+        float dt = static_cast<float> ( actual_delta_ms / MSEC_IN_SEC );
         q0 = K * ( 1 + TD / dt );
         q1 = K * ( -1 - 2 * TD / dt + 2 * dt / TI );
         q2 = K * TD / dt;

--- a/PAC/common/PID.cpp
+++ b/PAC/common/PID.cpp
@@ -123,8 +123,9 @@ float PID::eval( float currentValue, int deltaSign )
     if ( dt == 0 ) dt = 1;
     if ( TI == 0 ) TI = 0.0001f;
 
-    if ( get_delta_millisec( last_time ) > dt * MSEC_IN_SEC )
+    if ( auto eval_dt = get_delta_millisec( last_time ); eval_dt > dt * MSEC_IN_SEC )
         {
+        dt = eval_dt / MSEC_IN_SEC;
         q0 = K * ( 1 + TD / dt );
         q1 = K * ( -1 - 2 * TD / dt + 2 * dt / TI );
         q2 = K * TD / dt;

--- a/PAC/common/PID.cpp
+++ b/PAC/common/PID.cpp
@@ -92,7 +92,7 @@ float PID::eval( float currentValue, int deltaSign )
             }
         }
 
-    float dt = ( *par )[ P_dt ];
+    float set_delta_ms = ( *par )[ P_dt ];
     float dmax = ( *par )[ P_max ];
     float dmin = ( *par )[ P_min ];
 
@@ -110,7 +110,7 @@ float PID::eval( float currentValue, int deltaSign )
 
     if ( G_DEBUG )
         {
-        if ( dt == 0 )
+        if ( set_delta_ms == 0 )
             {
             printf( "Error! PID::eval() - dt = 0!\n" );
             }
@@ -120,12 +120,12 @@ float PID::eval( float currentValue, int deltaSign )
             }
         }
 
-    if ( dt == 0 ) dt = 1;
+    if ( set_delta_ms == 0 ) set_delta_ms = 1'000;
     if ( TI == 0 ) TI = 0.0001f;
 
-    if ( auto eval_dt = get_delta_millisec( last_time ); eval_dt > dt )
+    if ( auto actual_delta_ms = get_delta_millisec( last_time ); actual_delta_ms > set_delta_ms )
         {
-        dt = eval_dt / MSEC_IN_SEC;
+        auto dt = actual_delta_ms / MSEC_IN_SEC;
         q0 = K * ( 1 + TD / dt );
         q1 = K * ( -1 - 2 * TD / dt + 2 * dt / TI );
         q2 = K * TD / dt;

--- a/PAC/common/PID.cpp
+++ b/PAC/common/PID.cpp
@@ -126,7 +126,7 @@ float PID::eval( float currentValue, int deltaSign )
 
     if ( auto actual_delta_ms = get_delta_millisec( last_time ); actual_delta_ms > set_delta_ms )
         {
-        auto dt = static_cast<float>( actual_delta_ms / MSEC_IN_SEC );
+        auto dt = static_cast<float>( actual_delta_ms ) / MSEC_IN_SEC;
         q0 = K * ( 1 + TD / dt );
         q1 = K * ( -1 - 2 * TD / dt + 2 * dt / TI );
         q2 = K * TD / dt;

--- a/PAC/common/PID.h
+++ b/PAC/common/PID.h
@@ -129,6 +129,11 @@ class PID : public device, public i_Lua_save_device
             STOPPING = 10,
             };
 
+        enum class CONSTANTS
+            {
+            DEFAULT_DELTA_MS = 1'000
+            };
+
     private:
         float uk_1;
         float ek_1;


### PR DESCRIPTION
Fixes #920.
When the time delta between PID evaluations exceeds the configured `dt`,
the `dt` is recalculated to avoid integral windup.

This ensures that the PID controller responds appropriately even when
there are large gaps in the control loop.
