### PR TITLE
Adds error description for IOLink mix proof valve

### DIFF
--- a/PAC/common/device/valve.cpp
+++ b/PAC/common/device/valve.cpp
@@ -1453,6 +1453,53 @@ void valve_iolink_mix_proof::direct_set_state( int new_state )
         }
     }
 //-----------------------------------------------------------------------------
+const char* valve_iolink_mix_proof::get_error_description()
+    {
+    switch ( in_info.err )
+        {
+        case 0:
+            // Everything is OK.
+            break;
+        case 16:
+            return "sensor target missing (#16)";
+        case 17:
+            return "setup prerequisite issue (#17)";
+        case 18:
+            return "pneumatic part issue (#18)";
+        case 19:
+            return "seat-lift sensor issue (#19)";
+        case 20:
+            return "position not reached (#20)";
+        case 21:
+            return "unexpected movement (#21)";
+        case 22:
+            return "seat-lift sensor missing (#22)";
+        case 23:
+            return "pilot valve 1 missing (#23)";
+        case 24:
+            return "pilot valve 2 missing (#24)";
+        case 25:
+            return "pilot valve 3 missing (#25)";
+        case 26:
+            return "interlock active (#26)";
+        case 27:
+            return "output short circuit (#27)";
+        case 28:
+            return "setup aborted (#28)";
+        case 29:
+            return "blocked button (#29)";
+        case 30:
+            return "communication failure (#30)";
+        case 31:
+            return "safety stop active (#31)";
+        default:
+            return "unknown error";
+            break;
+        }
+
+    return "обратная связь";
+    }
+//-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 const std::string valve_iolink_shut_off_sorio::SORIO_ARTICLE = "DEF.SORIO-1SV";
 

--- a/PAC/common/device/valve.h
+++ b/PAC/common/device/valve.h
@@ -682,6 +682,8 @@ class valve_iolink_mix_proof : public i_mix_proof, public valve
 
         void direct_set_state( int new_state ) override;
 
+        const char* get_error_description() override;
+
 #ifndef PTUSA_TEST
     private:
 #endif

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -2850,6 +2850,60 @@ TEST( valve_iolink_mix_proof, get_state )
     G_PAC_INFO()->emulation_on();
     }
 
+class valve_iolink_mix_proof_testable : public valve_iolink_mix_proof
+    {
+    public:
+        explicit valve_iolink_mix_proof_testable( const char* dev_name )
+            : valve_iolink_mix_proof( dev_name )
+            {
+            }
+
+        void set_err( uint16_t err ) 
+            { 
+            in_info.err = err; 
+            }
+    };
+
+
+
+TEST( valve_iolink_mix_proof, get_error_description )
+    {
+    struct ErrorDescCase
+        {
+        uint16_t err;
+        const char* expected;
+        };
+
+    valve_iolink_mix_proof_testable v( "V1" );
+
+    const ErrorDescCase cases[] =
+        {
+        {0, "обратная связь"},
+        {16, "sensor target missing (#16)"},
+        {17, "setup prerequisite issue (#17)"},
+        {18, "pneumatic part issue (#18)"},
+        {19, "seat-lift sensor issue (#19)"},
+        {20, "position not reached (#20)"},
+        {21, "unexpected movement (#21)"},
+        {22, "seat-lift sensor missing (#22)"},
+        {23, "pilot valve 1 missing (#23)"},
+        {24, "pilot valve 2 missing (#24)"},
+        {25, "pilot valve 3 missing (#25)"},
+        {26, "interlock active (#26)"},
+        {27, "output short circuit (#27)"},
+        {28, "setup aborted (#28)"},
+        {29, "blocked button (#29)"},
+        {30, "communication failure (#30)"},
+        {31, "safety stop active (#31)"},
+        {99, "unknown error"}
+        };
+
+    for ( const auto& c : cases )
+        {
+        v.set_err( c.err );
+        EXPECT_STREQ( v.get_error_description(), c.expected ) << "err=" << c.err;
+        }
+    }
 
 TEST( valve_iolink_shut_off_thinktop, valve_iolink_shut_off_thinktop )
     {


### PR DESCRIPTION
Fixes #725.
Adds a function to retrieve an error description based on the error code reported by the IOLink mix proof valve.
Also adds unit tests for the new functionality.
