### PR TITLE
Adds emulator support for IOLink signal columns

### DIFF
--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -163,6 +163,11 @@ const char* signal_column_iolink::get_error_description()
 //-----------------------------------------------------------------------------
 int signal_column_iolink::get_state()
     {
+    if ( G_PAC_INFO()->is_emulator() )
+        {
+        return signal_column::get_state();
+        }
+
     if ( auto st = get_AI_IOLINK_state( 0 ); st != io_device::IOLINKSTATE::OK )
         {
         return -st;

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -734,6 +734,18 @@ TEST( signal_column, show_idle )
         "L_BLUE=0, L_SIREN=0},\n", buff );
     }
 
+
+TEST( signal_column_iolink, get_state )
+    {
+    signal_column_iolink test_dev( "test_HL1" );
+
+    EXPECT_EQ( test_dev.get_state(), 0 );
+
+    G_PAC_INFO()->emulation_off();
+    EXPECT_EQ( test_dev.get_state(), 0 );
+    G_PAC_INFO()->emulation_on();
+    }
+
 TEST_F( iolink_dev_test, signal_column_iolink_get_error_description )
     {
     signal_column_iolink test_dev( "test_HL1" );


### PR DESCRIPTION
Fixes #966.
Adds emulator support to `signal_column_iolink::get_state()` to call the base class's method when running in emulator mode, ensuring consistent behavior across different environments.
