### PR TITLE
Fixes parameters initialization in `tech_object`

### DIFF
--- a/PAC/common/cip_tech_def.cpp
+++ b/PAC/common/cip_tech_def.cpp
@@ -779,6 +779,11 @@ int cipline_tech_object::evaluate()
 
 int cipline_tech_object::init_params()
     {
+    if ( number == 1 )
+        {
+        parpar->reset_to_0();
+        }
+
     tech_object::init_params();
     rt_par_float[P_R_NO_FLOW] = 2;
     rt_par_float[P_TM_R_NO_FLOW] = 20;

--- a/PAC/common/cip_tech_def.cpp
+++ b/PAC/common/cip_tech_def.cpp
@@ -460,7 +460,7 @@ int cipline_tech_object::save_device( char *buff )
 
 
     //Выбор моющих средств
-    if (nmr == 1)
+    if ( nmr == FIRST_CIPLINE_OBJECT_NUMBER )
     {
         //Список доступных щелочных растворов
         answer_size += sprintf(buff + answer_size, "\tCAUSTIC_REC_LIST='%s',\n", causticRecipes->recipeList);
@@ -721,7 +721,7 @@ int cipline_tech_object::evaluate()
             }
         }
 
-    if (nmr == 1)
+    if ( nmr == FIRST_CIPLINE_OBJECT_NUMBER )
     {
         statsbase->evaluate();
     }
@@ -781,7 +781,7 @@ int cipline_tech_object::init_params()
     {
     tech_object::init_params();
 
-    if ( number == 1 )
+    if ( number == FIRST_CIPLINE_OBJECT_NUMBER )
         {
         parpar->reset_to_0();
         if ( scparams != parpar ) scparams->reset_to_0();
@@ -1105,7 +1105,7 @@ void cipline_tech_object::initline()
     check_Lua_function( "cip_On_Resume", is_On_Resume_func );
     check_Lua_function( "cip_ConfigureLine", is_ConfigureLine_func );
 
-    if (nmr == 1)
+    if ( nmr == FIRST_CIPLINE_OBJECT_NUMBER )
         {
         causticLoadedRecipe = (int)(parpar[0][P_CAUSTIC_SELECTED]);
         if (causticLoadedRecipe >= 0 && causticLoadedRecipe < TMediumRecipeManager::recipePerLine)

--- a/PAC/common/cip_tech_def.cpp
+++ b/PAC/common/cip_tech_def.cpp
@@ -779,38 +779,46 @@ int cipline_tech_object::evaluate()
 
 int cipline_tech_object::init_params()
     {
+    tech_object::init_params();
+
     if ( number == 1 )
         {
         parpar->reset_to_0();
+        if ( scparams != parpar ) scparams->reset_to_0();
         }
+    return 0;
+    }
 
-    tech_object::init_params();
-    rt_par_float[P_R_NO_FLOW] = 2;
-    rt_par_float[P_TM_R_NO_FLOW] = 20;
-    rt_par_float[P_TM_NO_FLOW_R] = 20;
-    rt_par_float[P_TM_NO_CONC] = 20;
-    rt_par_float[PIDP_Z] = 95;
-    rt_par_float[PIDP_k] = 2;
-    rt_par_float[PIDP_Ti] = 30;
-    rt_par_float[PIDP_Td] = (float)0.2;
-    rt_par_float[PIDP_dt] = 500;
-    rt_par_float[PIDP_dmax] = 130;
-    rt_par_float[PIDP_dmin] = 0;
-    rt_par_float[PIDP_AccelTime] = 30;
-    rt_par_float[PIDP_IsManualMode] = 0;
-    rt_par_float[PIDP_UManual] = 30;
-    rt_par_float[PIDP_Uk] = 0;
-    rt_par_float[PIDF_Z] = 15;
-    rt_par_float[PIDF_k] = (float)0.5;
-    rt_par_float[PIDF_Ti] = 10;
-    rt_par_float[PIDF_Td] = (float)0.1;
-    rt_par_float[PIDF_dt] = 1000;
-    rt_par_float[PIDF_dmax] = 40;
-    rt_par_float[PIDF_dmin] = 0;
-    rt_par_float[PIDF_AccelTime] = 2;
-    rt_par_float[PIDF_IsManualMode] = 0;
-    rt_par_float[PIDF_UManual] = 15;
-    rt_par_float[PIDF_Uk] = 0;
+int cipline_tech_object::init_runtime_params()
+    {
+    tech_object::init_runtime_params();
+
+    rt_par_float[ P_R_NO_FLOW ] = 2;
+    rt_par_float[ P_TM_R_NO_FLOW ] = 20;
+    rt_par_float[ P_TM_NO_FLOW_R ] = 20;
+    rt_par_float[ P_TM_NO_CONC ] = 20;
+    rt_par_float[ PIDP_Z ] = 95;
+    rt_par_float[ PIDP_k ] = 2;
+    rt_par_float[ PIDP_Ti ] = 30;
+    rt_par_float[ PIDP_Td ] = (float)0.2;
+    rt_par_float[ PIDP_dt ] = 500;
+    rt_par_float[ PIDP_dmax ] = 130;
+    rt_par_float[ PIDP_dmin ] = 0;
+    rt_par_float[ PIDP_AccelTime ] = 30;
+    rt_par_float[ PIDP_IsManualMode ] = 0;
+    rt_par_float[ PIDP_UManual ] = 30;
+    rt_par_float[ PIDP_Uk ] = 0;
+    rt_par_float[ PIDF_Z ] = 15;
+    rt_par_float[ PIDF_k ] = (float)0.5;
+    rt_par_float[ PIDF_Ti ] = 10;
+    rt_par_float[ PIDF_Td ] = (float)0.1;
+    rt_par_float[ PIDF_dt ] = 1000;
+    rt_par_float[ PIDF_dmax ] = 40;
+    rt_par_float[ PIDF_dmin ] = 0;
+    rt_par_float[ PIDF_AccelTime ] = 2;
+    rt_par_float[ PIDF_IsManualMode ] = 0;
+    rt_par_float[ PIDF_UManual ] = 15;
+    rt_par_float[ PIDF_Uk ] = 0;
     return 0;
     }
 

--- a/PAC/common/cip_tech_def.h
+++ b/PAC/common/cip_tech_def.h
@@ -541,6 +541,9 @@ class TSav
         float Q() const;
     };
 
+// Данная линия также содержит параметры станции CIP.
+constexpr int FIRST_CIPLINE_OBJECT_NUMBER = 1;
+
 class cipline_tech_object: public tech_object
     {
     protected:

--- a/PAC/common/cip_tech_def.h
+++ b/PAC/common/cip_tech_def.h
@@ -877,6 +877,7 @@ class cipline_tech_object: public tech_object
         int set_cmd( const char *prop, u_int idx, const char* val );
         int evaluate() override;
         int init_params() override;
+        int init_runtime_params() override;
 
         ////-------------------
         void RHI();

--- a/PAC/common/cip_tech_def.h
+++ b/PAC/common/cip_tech_def.h
@@ -876,7 +876,7 @@ class cipline_tech_object: public tech_object
         int set_cmd( const char *prop, u_int idx, double val ) override;
         int set_cmd( const char *prop, u_int idx, const char* val );
         int evaluate() override;
-        int init_params();
+        int init_params() override;
 
         ////-------------------
         void RHI();

--- a/PAC/common/tech_def.cpp
+++ b/PAC/common/tech_def.cpp
@@ -715,7 +715,7 @@ int tech_object::lua_init_params()
     {
     init_params();
 
-    auto function_names = 
+    static const auto LUA_INIT_FUNCTIONS = 
         {
         "init_params_uint",
         "init_params_float",
@@ -724,7 +724,7 @@ int tech_object::lua_init_params()
         };
 
     auto res = 0;
-    for ( auto f_name : function_names )
+    for ( auto f_name : LUA_INIT_FUNCTIONS )
         {
         if ( G_LUA_MANAGER->is_exist_lua_function( name_Lua, f_name ) )
             {

--- a/PAC/common/tech_def.cpp
+++ b/PAC/common/tech_def.cpp
@@ -715,65 +715,32 @@ int tech_object::lua_init_params()
     {
     init_params();
 
-    //Проверка на наличии функции инициализации параметров uint.
-    lua_getfield( lua_manager::get_instance()->get_Lua(), LUA_GLOBALSINDEX,
-        name_Lua );
-    lua_getfield( lua_manager::get_instance()->get_Lua(), -1, "init_params_uint" );
-    lua_remove( lua_manager::get_instance()->get_Lua(), -2 );
-
-    if ( lua_isfunction( lua_manager::get_instance()->get_Lua(), -1 ) )
+    auto function_names = 
         {
-        lua_manager::get_instance()->int_exec_lua_method( name_Lua,
-            "init_params_uint", 0, "int tech_object::lua_init_params()" );
-        }
-    //Удаляем "init_params_uint" со стека.
-    lua_remove( lua_manager::get_instance()->get_Lua(), -1 );
+        "init_params_uint",
+        "init_params_float",
+        "init_rt_params_uint",
+        "init_rt_params_float"
+        };
 
-    //Проверка на наличии функции инициализации параметров float.
-    lua_getfield( lua_manager::get_instance()->get_Lua(), LUA_GLOBALSINDEX,
-        name_Lua );
-    lua_getfield( lua_manager::get_instance()->get_Lua(), -1, "init_params_float" );
-    lua_remove( lua_manager::get_instance()->get_Lua(), -2 );
-
-    if ( lua_isfunction( lua_manager::get_instance()->get_Lua(), -1 ) )
+    auto res = 0;
+    for ( auto f_name : function_names )
         {
-        lua_manager::get_instance()->int_exec_lua_method( name_Lua,
-            "init_params_float", 0, "int tech_object::lua_init_params()" );
+        if ( G_LUA_MANAGER->is_exist_lua_function( name_Lua, f_name ) )
+            {
+            auto init_res = lua_manager::get_instance()->int_exec_lua_method( name_Lua,
+                f_name, 0, fmt::format(
+                "int tech_object::lua_init_params() for function '{}'",
+                f_name ).c_str() );
+
+            if ( init_res != 0 )
+                {
+                res = init_res;
+                }
+            }
         }
-    //Удаляем "init_params_float" со стека.
-    lua_remove( lua_manager::get_instance()->get_Lua(), -1 );
 
-    //Проверка на наличии функции инициализации рабочих параметров uint.
-    lua_getfield( lua_manager::get_instance()->get_Lua(), LUA_GLOBALSINDEX,
-        name_Lua );
-    lua_getfield( lua_manager::get_instance()->get_Lua(), -1,
-        "init_rt_params_uint" );
-    lua_remove( lua_manager::get_instance()->get_Lua(), -2 );
-
-    if ( lua_isfunction( lua_manager::get_instance()->get_Lua(), -1 ) )
-        {
-        lua_manager::get_instance()->int_exec_lua_method( name_Lua,
-            "init_rt_params_uint", 0, "int tech_object::lua_init_params()" );
-        }
-    //Удаляем "init_params_uint" со стека.
-    lua_remove( lua_manager::get_instance()->get_Lua(), -1 );
-
-    //Проверка на наличии функции инициализации рабочих параметров float.
-    lua_getfield( lua_manager::get_instance()->get_Lua(), LUA_GLOBALSINDEX,
-        name_Lua );
-    lua_getfield( lua_manager::get_instance()->get_Lua(), -1,
-        "init_rt_params_float" );
-    lua_remove( lua_manager::get_instance()->get_Lua(), -2 );
-
-    if ( lua_isfunction( lua_manager::get_instance()->get_Lua(), -1 ) )
-        {
-        lua_manager::get_instance()->int_exec_lua_method( name_Lua,
-            "init_rt_params_float", 0, "int tech_object::lua_init_params()" );
-        }
-    //Удаляем "init_params_float" со стека.
-    lua_remove( lua_manager::get_instance()->get_Lua(), -1 );
-
-    return 0;
+    return res;
     }
 //-----------------------------------------------------------------------------
 int tech_object::lua_init_runtime_params()

--- a/PAC/common/tech_def.cpp
+++ b/PAC/common/tech_def.cpp
@@ -778,7 +778,7 @@ int tech_object::lua_init_params()
 //-----------------------------------------------------------------------------
 int tech_object::lua_init_runtime_params()
     {
-    tech_object::init_runtime_params();
+    init_runtime_params();
 
     return lua_manager::get_instance()->int_exec_lua_method( name_Lua,
         "init_runtime_params", 0, "int tech_object::lua_init_runtime_params()" );

--- a/PAC/common/tech_def.cpp
+++ b/PAC/common/tech_def.cpp
@@ -713,7 +713,7 @@ int tech_object::lua_final_mode( u_int mode )
 //-----------------------------------------------------------------------------
 int tech_object::lua_init_params()
     {
-    tech_object::init_params();
+    init_params();
 
     //Проверка на наличии функции инициализации параметров uint.
     lua_getfield( lua_manager::get_instance()->get_Lua(), LUA_GLOBALSINDEX,

--- a/PAC/common/tech_def.h
+++ b/PAC/common/tech_def.h
@@ -133,7 +133,7 @@ class tech_object: public i_tech_object, public i_Lua_save_device,
         /// @brief Инициализирует сохраняемые параметры значением 0.
         ///
         /// Данные нулевые значения сохраняются в энергонезависимой памяти.
-        int init_params();
+        virtual int init_params();
 
         /// @brief Инициализирует рабочие параметры значением 0.
         int init_runtime_params();

--- a/PAC/common/tech_def.h
+++ b/PAC/common/tech_def.h
@@ -136,7 +136,7 @@ class tech_object: public i_tech_object, public i_Lua_save_device,
         virtual int init_params();
 
         /// @brief Инициализирует рабочие параметры значением 0.
-        int init_runtime_params();
+        virtual int init_runtime_params();
 
         /// @brief Выполнение команды.
         ///

--- a/test/cip_tech_def_tests.cpp
+++ b/test/cip_tech_def_tests.cpp
@@ -94,7 +94,7 @@ void ClearCipDevices( )
     }
 
 
-TEST( cipline_tech_object, init_params )
+TEST( cipline_tech_object, lua_init_params )
     {
     cipline_tech_object cip1( "CIP1", 1, 1, "CIP1", 1, 1, 200, 200, 200, 200 );
     lua_manager::get_instance()->set_Lua( lua_open() );
@@ -102,20 +102,20 @@ TEST( cipline_tech_object, init_params )
     const auto PAR_VALUE = 1.5f;
     cipline_tech_object::set_station_par( P_CZAD_S, PAR_VALUE );
     EXPECT_EQ( cip1.get_station_par( P_CZAD_S ), PAR_VALUE );
-    cip1.init_params();
+    cip1.lua_init_params();
     EXPECT_EQ( cip1.get_station_par( P_CZAD_S ), 0.0f );
 
     G_LUA_MANAGER->free_Lua();
     }
 
-TEST( cipline_tech_object, init_runtime_params )
+TEST( cipline_tech_object, lua_init_runtime_params )
     {
     cipline_tech_object cip1( "CIP1", 1, 1, "CIP1", 1, 1, 200, 200, 200, 200 );
     lua_manager::get_instance()->set_Lua( lua_open() );
 
     // После создания объекта параметры должны иметь 0-е значения.
     EXPECT_EQ( cip1.rt_par_float[ workParameters::P_R_NO_FLOW ], 0.0f );
-    cip1.init_runtime_params();
+    cip1.lua_init_runtime_params();
     const auto PAR_VALUE = 2.f;
     // После инициализации рабочих параметров должны быть значения по умолчанию.
     EXPECT_EQ( cip1.rt_par_float[ workParameters::P_R_NO_FLOW ], PAR_VALUE );

--- a/test/cip_tech_def_tests.cpp
+++ b/test/cip_tech_def_tests.cpp
@@ -93,6 +93,37 @@ void ClearCipDevices( )
     device_manager::get_instance( )->clear_io_devices();
     }
 
+
+TEST( cipline_tech_object, init_params )
+    {
+    cipline_tech_object cip1( "CIP1", 1, 1, "CIP1", 1, 1, 200, 200, 200, 200 );
+    lua_manager::get_instance()->set_Lua( lua_open() );
+
+    const auto PAR_VALUE = 1.5f;
+    cipline_tech_object::set_station_par( P_CZAD_S, PAR_VALUE );
+    EXPECT_EQ( cip1.get_station_par( P_CZAD_S ), PAR_VALUE );
+    cip1.init_params();
+    EXPECT_EQ( cip1.get_station_par( P_CZAD_S ), 0.0f );
+
+    G_LUA_MANAGER->free_Lua();
+    }
+
+TEST( cipline_tech_object, init_runtime_params )
+    {
+    cipline_tech_object cip1( "CIP1", 1, 1, "CIP1", 1, 1, 200, 200, 200, 200 );
+    lua_manager::get_instance()->set_Lua( lua_open() );
+
+    // После создания объекта параметры должны иметь 0-е значения.
+    EXPECT_EQ( cip1.rt_par_float[ workParameters::P_R_NO_FLOW ], 0.0f );
+    cip1.init_runtime_params();
+    const auto PAR_VALUE = 2.f;
+    // После инициализации рабочих параметров должны быть значения по умолчанию.
+    EXPECT_EQ( cip1.rt_par_float[ workParameters::P_R_NO_FLOW ], PAR_VALUE );
+
+    G_LUA_MANAGER->free_Lua();
+    }
+
+
 TEST( cipline_tech_object, _CheckErr )
     {
     cipline_tech_object cip1( "CIP1", 1, 1, "CIP1", 1, 1, 200, 200, 200, 200 );


### PR DESCRIPTION
Fixes #873.
Ensures that derived classes can properly override the `init_params` method for custom initialization logic.
