### PR TITLE
Adds error message on CIP evaluation failure

### DIFF
--- a/PAC/common/cip_tech_def.cpp
+++ b/PAC/common/cip_tech_def.cpp
@@ -3,6 +3,8 @@
 #pragma warning(disable: 4244)
 #endif // WIN_OS
 
+#include <fmt/core.h>
+
 #include "cip_tech_def.h"
 #include "lua_manager.h"
 #include "utf2cp1251.h"
@@ -2624,6 +2626,10 @@ int cipline_tech_object::EvalCipInProgress()
             state = res;
             Stop(curstep);
             state = res;
+
+            set_err_msg( fmt::format( "ошибка {}", res ).c_str(),
+                0, 0, ERR_MSG_TYPES::ERR_ALARM);
+
             return res;
             }
         else


### PR DESCRIPTION
Fixes #974.
Adds an error message when CIP evaluation fails, providing more context to the user when the system encounters an unexpected state. The message includes the error code.
