### PR TITLE
[config][git] Adds build directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ intermediate
 bin*
 out
 obj
+build
 cmake-build-*
 CMakeSettings.json
 nvram.txt


### PR DESCRIPTION
Prevents tracking of the build directory. This avoids committing generated files.
