### PR TITLE
Adds user check for workflow execution

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,10 +18,45 @@ env:
   CCACHE_VERSION: 4.2.1
 
 jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    outputs:
+        result: ${{ steps.pass.outputs.result }}
+
+    steps:
+      - id: is_organization_member
+        run: >
+          $response = (curl -L
+          -w '%{http_code}'
+          -H "Accept: application/vnd.github+json"
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+          -H "X-GitHub-Api-Version: 2022-11-28"
+          https://api.github.com/orgs/savushkin-r-d/members/${{ github.event.sender.login }})
+
+          echo "response=$response" >> $env:GITHUB_OUTPUT
+          continue-on-error: true
+
+      - id: pass
+        if: >-
+          (github.repository == 'savushkin-r-d/ptusa_main') &&
+          ((github.event_name == 'push') ||
+          (github.event_name == 'schedule') ||
+          (github.event.action == 'labeled' && github.event.label.name == 'safe to test') ||
+          ((github.event.action == 'pull_request_target') && steps.is_organization_member.outputs.response == '204') ||
+          github.event_name == 'merge_group' ||
+          startsWith(github.ref, 'refs/tags/') )
+        run: echo "result=success" >> $env:GITHUB_OUTPUT
+
+      - name: exit with failure
+        if: steps.pass.outputs.result != 'success'
+        run: exit 1
+
   build:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
-    if: ${{ (github.repository == 'savushkin-r-d/ptusa_main') && ( (github.event_name == 'push') || (github.event_name == 'schedule') || (github.event_name == 'merge_group') || ((github.event_name == 'pull_request_target') && (contains( github.event.pull_request.labels.*.name, 'safe to test' )))) }}
+    needs: check
+    if: needs.check.outputs.result == 'success'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Prevents workflow execution for external users.
It checks if the user is a member of the organization
before proceeding with the build. Also enables execution
if a pull request has a "safe to test" label or the ref is a tag.
This adds an extra layer of security and control over the
CI/CD pipeline.
