### PR TITLE
Adds watchdog device functionality to monitor CIP

### DIFF
--- a/PAC/common/cip_tech_def.h
+++ b/PAC/common/cip_tech_def.h
@@ -234,6 +234,7 @@ const int ERR_LEVEL_TANK_W = -38;
 const int ERR_SUPPLY_TEMP_SENSOR = -39;
 const int ERR_RETURN_TEMP_SENSOR = -40;
 const int ERR_CONCENTRATION_SENSOR = -41;
+const int ERR_WATCHDOG = -42;
 
 const int ERR_NO_DESINFECTION_MEDIUM = -71;
 const int ERR_DESINFECTION_MEDIUM_MAX_TIME = -72;
@@ -392,6 +393,9 @@ enum workParameters
     P_DONT_USE_WATER_TANK,              //Не использовать вторичную воду при мойке
     P_PIDP_MAX_OUT,                     //Верхняя граница пересчета выхода ПИД-регулятора подогрева
     P_PIDF_MAX_OUT,                     //Верхняя граница пересчета выхода ПИД-регулятора потока
+
+    P_WATCHDOG,                         //Строжевой таймер связи с проектом объекта CIP.
+
     P_RESERV_START,                     //начало резервных параметров
 
 
@@ -413,7 +417,6 @@ enum workParameters
     STP_PODP_CAUSTIC,   //количество подпиток на щелочи
     STP_PODP_ACID,      //количество подпиток на кислоте
     STP_PODP_WATER,     //количество подпиток на воде
-
     };
 
 //+++Параметры для самоочистки+++
@@ -869,7 +872,12 @@ class cipline_tech_object: public tech_object
         device* dev_ao_temp_task;               //Сигнал "задание температуры"
         device* dev_upr_wash_aborted;           //Сигнал "мойка закончена некорректно"
 
+        device* dev_watchdog = nullptr;         //Watchdog связь объекта мойки.
+
         int init_object_devices();			//Функция для инициализации устройств объекта мойки
+
+        int check_device( device*& outdev, int parno, device::DEVICE_TYPE );
+
         int check_DI(device*& outdev, int parno);
         int check_DO(device*& outdev, int parno);
         int check_AI(device*& outdev, int parno);


### PR DESCRIPTION
Introduces a watchdog device to monitor the CIP object's state.

This commit implements the following:
- Adds a watchdog device to the CIP object, which is initialized during object creation.
- Includes a check for the watchdog device's state in the error checking and step execution logic. The CIP object is considered not ready if the watchdog is not active.
- Introduces a helper function to check a device's validity.

This ensures that the CIP object is only considered ready and operational if the watchdog device is active, thus providing an additional layer of safety and monitoring.
