### PR TITLE
[fix] Limits control module name length

### DIFF
--- a/PAC/common/device/base.cpp
+++ b/PAC/common/device/base.cpp
@@ -362,7 +362,14 @@ device::device( const char* dev_name, DEVICE_TYPE type, DEVICE_SUB_TYPE sub_type
     {
     if ( dev_name )
         {
-        strcpy( this->name, dev_name );
+        auto [out, size] = fmt::format_to_n(
+            this->name, device::CONSTANTS::C_MAX_NAME, "{}", dev_name );
+        *out = '\0';
+        if ( size >= device::CONSTANTS::C_MAX_NAME )
+            {
+            G_LOG->critical( "Error create device '%s' - name truncated to `%s`!",
+                dev_name, this->name );
+            }
         }
     else
         {
@@ -370,11 +377,11 @@ device::device( const char* dev_name, DEVICE_TYPE type, DEVICE_SUB_TYPE sub_type
         }
 
     description = new char[ 1 ];
-    description[ 0 ] = 0;
+    description[ 0 ] = '\0';
 
     article = new char[ 2 ];
     article[ 0 ] = ' ';
-    article[ 1 ] = 0;
+    article[ 1 ] = '\0';
     }
 //-----------------------------------------------------------------------------
 const char* device::get_type_str() const

--- a/PAC/common/device/base.h
+++ b/PAC/common/device/base.h
@@ -374,7 +374,7 @@ class device : public i_DO_AO_device, public par_device
 
         enum CONSTANTS
             {
-            C_MAX_NAME = 20,
+            C_MAX_NAME = 30,
             C_MAX_DESCRIPTION = 100
             };
 
@@ -778,7 +778,7 @@ class device : public i_DO_AO_device, public par_device
 
         bool is_manual_mode = false; ///< Признак ручного режима.
 
-        char name[ C_MAX_NAME ];
+        char name[ C_MAX_NAME + 1 ];
         char* description;
 
         bool emulation = false;

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -1126,6 +1126,14 @@ TEST( device, device )
     EXPECT_STREQ( dev.get_name(), "?" );
     }
 
+TEST( device, device_too_long_name )
+    {
+    device dev( "VERY_VERY_LONG_DEVICE_NAME_MORE_THAN_30_SYMBOLS",
+        device::DEVICE_TYPE::DT_NONE,
+        device::DEVICE_SUB_TYPE::DST_NONE, 0 );
+    EXPECT_STREQ( dev.get_name(), "VERY_VERY_LONG_DEVICE_NAME_MOR" );
+    }
+
 TEST( device, get_type_str )
     {
     device dev1( "DEV1", device::DEVICE_TYPE::DT_NONE,


### PR DESCRIPTION
Ensures that device names do not exceed the maximum allowed length by truncating them and logging a critical error message if they do.

Increases device name size and adds null terminator to prevent buffer overflows.

Adds a new test case to verify name truncation.
