### PR TITLE
[config][github actions] Disables man-db auto-update on Linux

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -123,9 +123,9 @@ jobs:
         restore-keys: |
           ${{ matrix.config.name }}-ccache-
 
-    - name: Disable man-db cash (Linux only)
+    - name: Disable man-db cache (Linux only)
       if: runner.os == 'Linux'
-      run: sudo echo "set man-db/auto-update false" | sudo debconf-communicate; sudo dpkg-reconfigure man-db
+      run: echo 'man-db man-db/auto-update boolean false' | sudo debconf-set-selections && sudo dpkg-reconfigure man-db
 
     - name: Install yasm
       shell: cmake -P {0}


### PR DESCRIPTION
Prevents the man-db auto-update process from interfering with the build process on Linux runners. This avoids delays during CI.
