### PR TITLE
[config][github actions] Restricts CodeQL analysis to master branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["*"]
+    branches: [ master ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ["*"]
+    branches: [ master ]
     paths-ignore:
       - '**/*.md'
   schedule:


### PR DESCRIPTION
Limits CodeQL analysis to the master branch for both push and pull request events.

This prevents analysis from running on all branches, reducing unnecessary resource consumption and noise.
