### PR TITLE
[config][github actions] Updates pull request trigger events

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
   pull_request_target:
     branches: [ master ]
-    types: [ labeled ]
+    types: [ labeled, opened, reopened, synchronize ]
   merge_group:
     types: [ checks_requested ]
 
@@ -39,7 +39,11 @@ jobs:
           (
             github.event_name == 'pull_request_target' &&
             github.event.pull_request.head.repo.full_name != github.repository &&
-            contains(github.event.pull_request.labels.*.name, 'safe to test')
+            (
+              contains(github.event.pull_request.labels.*.name, 'safe to test') ||
+              github.event.pull_request.author_association == 'MEMBER' ||
+              github.event.pull_request.author_association == 'OWNER'
+            )
           ) ||
           (
             github.event_name == 'pull_request' &&

--- a/.github/workflows/sonar_build.yml
+++ b/.github/workflows/sonar_build.yml
@@ -9,7 +9,7 @@ on:
     branches: [ master ]
   pull_request_target:
     branches: [ master ]
-    types: [ labeled ]
+    types: [ labeled, opened, reopened, synchronize ]
   merge_group:
     types: [ checks_requested ]
 
@@ -26,7 +26,11 @@ jobs:
           (
             github.event_name == 'pull_request_target' &&
             github.event.pull_request.head.repo.full_name != github.repository &&
-            contains(github.event.pull_request.labels.*.name, 'safe to test')
+            (
+              contains(github.event.pull_request.labels.*.name, 'safe to test') ||
+              github.event.pull_request.author_association == 'MEMBER' ||
+              github.event.pull_request.author_association == 'OWNER'
+            )
           ) ||
           (
             github.event_name == 'pull_request' &&


### PR DESCRIPTION
Extends the pull request target trigger events to include 'opened',
'reopened', and 'synchronize'. This ensures that CI pipelines are
triggered not only on labeled pull requests, but also when a new pull
request is opened, reopened, or synchronized with the base branch from
members and owners.
