### PR TITLE
Fixes `EY` device IO evaluation in emulator mode

### DIFF
--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -4070,7 +4070,7 @@ void converter_iolink_ao::direct_on()
 
     v = 100.0f;
     v2 = 100.0f;
-    st = 1;
+    analog_io_device::direct_on();
     }
 
 void converter_iolink_ao::direct_off()
@@ -4080,7 +4080,7 @@ void converter_iolink_ao::direct_off()
 
     v = 0.0f;
     v2 = 0.0f;
-    st = 0;
+    analog_io_device::direct_off();
     }
 
 float converter_iolink_ao::get_value()
@@ -4100,7 +4100,7 @@ int converter_iolink_ao::get_state()
         return -err;
         }
 
-    return st;
+    return analog_io_device::get_state();
     }
 
 uint16_t converter_iolink_ao::calc_setpoint( float &val ) const
@@ -4131,8 +4131,8 @@ void converter_iolink_ao::set_value2( float val )
 
 void converter_iolink_ao::calculate_state()
     {
-    if ( v > 0.0f || v2 > 0.0f ) st = 1;
-    else if ( v == 0.0f && v2 == 0.0f ) st = 0;
+    if ( v > 0.0f || v2 > 0.0f ) analog_io_device::direct_on();
+    else if ( v == 0.0f && v2 == 0.0f ) analog_io_device::direct_off();
     }
 
 void converter_iolink_ao::evaluate_io()

--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -4137,6 +4137,8 @@ void converter_iolink_ao::calculate_state()
 
 void converter_iolink_ao::evaluate_io()
     {
+    if ( G_PAC_INFO()->is_emulator() ) return;
+
     auto data = reinterpret_cast<std::byte*>( get_AI_data( C_AIAO_INDEX ) );
 
     if ( !data ) return; // Return, if data is nullptr (in debug mode).

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -1798,7 +1798,6 @@ class converter_iolink_ao : public analog_io_device
 
         float v{};  // Выходное значение канала 1.
         float v2{}; // Выходное значение канала 2.
-        int st{};   // Состояние устройства.
         int err{};  // Ошибка.
 
         enum CONSTANTS

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -5801,7 +5801,15 @@ TEST_F( iolink_dev_test, converter_iolink_ao_get_state )
     EXPECT_EQ( Y1.get_state(), 0 );
     init_channels( Y1 );
     Y1.evaluate_io();
-    EXPECT_EQ( Y1.get_state(), OFF  );
+    EXPECT_EQ( Y1.get_state(), 0  );
+
+    Y1.set_cmd( "ST", 0, 1 );
+    Y1.evaluate_io();
+    EXPECT_EQ( Y1.get_state(), 1 );
+
+    Y1.set_cmd( "ST", 0, -100 );
+    Y1.evaluate_io();
+    EXPECT_EQ( Y1.get_state(), -100 );
     }
 
 

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -5801,7 +5801,7 @@ TEST_F( iolink_dev_test, converter_iolink_ao_get_state )
     EXPECT_EQ( Y1.get_state(), 0 );
     init_channels( Y1 );
     Y1.evaluate_io();
-    EXPECT_EQ( Y1.get_state(), 0  );
+    EXPECT_EQ( Y1.get_state(), 0 );
 
     Y1.set_cmd( "ST", 0, 1 );
     Y1.evaluate_io();

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -5792,6 +5792,19 @@ TEST_F( iolink_dev_test, converter_iolink_ao_evaluate_io )
     }
 
 
+TEST_F( iolink_dev_test, converter_iolink_ao_get_state )
+    {
+    // В режиме эмуляции состояние всегда 0.
+    converter_iolink_ao Y1( "Y1" );
+    EXPECT_EQ( Y1.get_state(), 0 );
+    Y1.evaluate_io();
+    EXPECT_EQ( Y1.get_state(), 0 );
+    init_channels( Y1 );
+    Y1.evaluate_io();
+    EXPECT_EQ( Y1.get_state(), OFF  );
+    }
+
+
 TEST( device_manager, get_EY )
     {
     // Cleanup before test.

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -5794,7 +5794,7 @@ TEST_F( iolink_dev_test, converter_iolink_ao_evaluate_io )
 
 TEST_F( iolink_dev_test, converter_iolink_ao_get_state )
     {
-    // В режиме эмуляции состояние всегда 0.
+    // In emulator mode, state is always 0.
     converter_iolink_ao Y1( "Y1" );
     EXPECT_EQ( Y1.get_state(), 0 );
     Y1.evaluate_io();


### PR DESCRIPTION
Fixes #1050. 
Prevents IO evaluation for `converter_iolink_ao` when running in emulator mode.
This ensures consistent behavior during testing and development,
as the IO operations are not relevant in the emulated environment.
