### PR TITLE
[fix] Ensures consistent path separators

### DIFF
--- a/common/lua_manager.cpp
+++ b/common/lua_manager.cpp
@@ -130,8 +130,21 @@ int lua_manager::init( lua_State* lua_state, const char* script_name,
     std::string dir_str( dir );
     std::string sys_dir_str( sys_dir );
     std::string extra_dirs_str( extra_dirs );
-    
 
+    if ( !dir_str.empty() && dir_str.back() != '\\' && dir_str.back() != '/' )
+        {
+        dir_str += '/';
+        }
+    if ( !sys_dir_str.empty() && 
+        sys_dir_str.back() != '\\' && sys_dir_str.back() != '/' )
+        {
+        sys_dir_str += '/';
+        }
+    if ( !extra_dirs_str.empty() && 
+        extra_dirs_str.back() != '\\' && extra_dirs_str.back() != '/' )
+        {
+        extra_dirs_str += '/';
+        }
     if ( !dir_str.empty() || !sys_dir_str.empty() || !extra_dirs_str.empty() )
         {
         G_LOG->notice( "current working directory: \"%s\"",
@@ -139,21 +152,6 @@ int lua_manager::init( lua_State* lua_state, const char* script_name,
 
         G_LOG->notice( "path = \"%s\", sys_path = \"%s\", extra_paths = \"%s\"",
             dir_str.c_str(), sys_dir_str.c_str(), extra_dirs_str.c_str() );
-        }
-
-    if ( !dir_str.empty() && dir_str.back() != '\\' && dir_str.back() != '/' )
-        {
-        dir_str += std::filesystem::path::preferred_separator;
-        }
-    if ( !sys_dir_str.empty() && 
-        sys_dir_str.back() != '\\' && sys_dir_str.back() != '/' )
-        {
-        sys_dir_str += std::filesystem::path::preferred_separator;
-        }
-    if ( !extra_dirs_str.empty() && 
-        extra_dirs_str.back() != '\\' && extra_dirs_str.back() != '/' )
-        {
-        extra_dirs_str += std::filesystem::path::preferred_separator;
         }
 
     if ( 0 == lua_state )


### PR DESCRIPTION
Enforces the use of forward slashes as path separators in directory strings,
regardless of the operating system's preferred separator.
