### PR TITLE
[fix] Initializes output data for converter IO-Link AO

### DIFF
--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -4071,7 +4071,9 @@ motor_altivar_linear::motor_altivar_linear( const char* dev_name ) :
 converter_iolink_ao::converter_iolink_ao( const char* dev_name ) :
     analog_io_device( dev_name, device::DT_EY, device::DST_CONV_AO2, 0 )
     {
-    memset( &p_data_in, 0, sizeof( p_data_in ) );
+#ifdef PTUSA_TEST
+    stub_p_data_out = {};
+#endif    
 
     static_assert( sizeof( process_data_in ) == PROCESS_DATA_IN_SIZE,
         "Struct `process_data_in` must be the 1 byte size." );

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -1863,7 +1863,7 @@ class converter_iolink_ao : public analog_io_device
             };
 #pragma pack(pop)
 
-        process_data_in p_data_in{ 0 };
+        process_data_in p_data_in{};
 
         inline static process_data_out stub_p_data_out{};
         process_data_out* p_data_out = &stub_p_data_out;


### PR DESCRIPTION
Initializes the output data structure for the converter IO-Link AO device. This ensures a clean state for output values, especially within test environments, preventing undefined behavior.
