### PR TITLE
[config][cmake] Removes stack protector disabling logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,24 +381,8 @@ if(WIN32)
 elseif (LINUX)
     target_link_libraries(libptusa_main liblua_static)
 endif()
+
 #######################################################################################
-
-
-if(MINGW OR CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    # Отключить генерацию защит стека, чтобы линковщик не требовал libssp.
-    add_compile_options(-fno-stack-protector)
-
-    # Почистить все распространённые переменные линковки от -lssp
-    foreach(VAR CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS
-                CMAKE_MODULE_LINKER_FLAGS CMAKE_C_STANDARD_LIBRARIES
-                CMAKE_CXX_STANDARD_LIBRARIES)
-        if(DEFINED ${VAR})
-            string(REPLACE "-lssp" "" ${VAR} "${${VAR}}")
-        endif()
-    endforeach()
-endif()
-
-
 if(ARP_DEVICE)
     string(REGEX REPLACE "^.*\\(([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+).*$" "\\1" _ARP_SHORT_DEVICE_VERSION ${ARP_DEVICE_VERSION})
     install(TARGETS ${PROJECT_NAME} libptusa_main PtusaPLCnextEngineer


### PR DESCRIPTION
Removes the disabling of stack protection and the associated linker flag cleanup. This logic was introduced to resolve linker issues related to `libssp` but is no longer necessary.
