### PR TITLE
[config][github actions] Enables `ccache` for faster builds

### DIFF
--- a/.github/workflows/sonar_build.yml
+++ b/.github/workflows/sonar_build.yml
@@ -67,6 +67,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ccache-
           max-size: 500M
+          cache-dir: ${{ github.workspace }}/.ccache
 
       # Disable man-db cache. Install unixodbc-dev.
       - name: Install unixodbc-dev


### PR DESCRIPTION
Implements ccache to speed up the build process by caching
compiler outputs. This includes setting up ccache in the workflow,
installing it, and configuring CMake to use it. It reduces build times.
