### PR TITLE
[config][github actions] Configures `CMake` build for `CodeQL` analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,7 @@ on:
       - '**/*.md'
   schedule:
     - cron: '0 9 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Replaces the default CodeQL autobuild process with a manual CMake configuration and build.
