### PR TITLE
Refactors and initializes `PAC_info` members

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
-################# create targets ######################################################
+################# create targets ##############################################
 
 if(LINUX)
     add_compile_definitions(LINUX_OS)
@@ -60,22 +60,38 @@ add_subdirectory(deps/toluapp EXCLUDE_FROM_ALL)
 
 add_subdirectory(deps/zlib EXCLUDE_FROM_ALL)
 
+# Google Test configuration.
 set(INSTALL_GTEST OFF)
+set(INSTALL_GMOCK OFF)
+# Build as static libraries to avoid DLL export issues.
+set(BUILD_SHARED_LIBS OFF)
+# Use dynamic CRT (/MD) to match the main project.
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Скрыть внутренние символы для уменьшения размера бинарника.
+set(gtest_hide_internal_symbols ON CACHE BOOL "" FORCE)
 add_subdirectory(deps/googletest EXCLUDE_FROM_ALL)
-foreach(_t gtest gtest_main gmock gmock_main)
-    if(TARGET ${_t})
-        set_target_properties(${_t} PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/$<CONFIG>"
-            LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/$<CONFIG>"
-            ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/$<CONFIG>")
-    endif()
-endforeach()
+set(BUILD_SHARED_LIBS ON)
 
 add_subdirectory(deps/subhook EXCLUDE_FROM_ALL)
 
+# Google Benchmark configuration.
 if(NOT MINGW)
-    set (BENCHMARK_ENABLE_TESTING OFF)
+    # Не собирать внутренние тесты benchmark.
+    set(BENCHMARK_ENABLE_TESTING OFF)
+    # Не использовать libc++ (MSVC использует свою STL).
+    set(BENCHMARK_USE_LIBCXX OFF)
+    # Собирать как статическую библиотеку.
+    set(BUILD_SHARED_LIBS OFF)
+    # Не создавать install targets.
+    set(BENCHMARK_ENABLE_INSTALL OFF)
+    if(WIN32)
+        # Отключить GTest-тесты benchmark (требуют pthreads).
+        set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
+        # Использовать Win32 threads вместо pthreads.
+        set(CMAKE_USE_WIN32_THREADS_INIT ON)
+    endif()
     add_subdirectory(deps/benchmark EXCLUDE_FROM_ALL)
+    set(BUILD_SHARED_LIBS ON)
 endif()
 
 if(USE_OPCUA)
@@ -210,8 +226,9 @@ elseif(WIN32)
     endif()
 endif()
 
-add_dependencies(main_test lua lfs luasystem term_core luassert_copy)
-add_dependencies(lua libptusa_main luasql_odbc)
+add_dependencies(main_test lua lfs luasystem term_core luassert_copy
+    luasql_odbc)
+add_dependencies(libptusa_main lua)
 
 if(MSVC)
     set_property(TARGET libptusa_main PROPERTY VS_DEBUGGER_COMMAND "lua.exe")
@@ -254,12 +271,11 @@ endif()
 set_target_properties (libptusa_main PROPERTIES OUTPUT_NAME ptusa_main PREFIX "")
 target_compile_definitions(libptusa_main PUBLIC _USRDLL)
 
-target_compile_definitions(gmock PUBLIC GTEST_CREATE_SHARED_LIBRARY)
-target_compile_definitions(main_test PUBLIC GTEST_LINKED_AS_SHARED_LIBRARY PTUSA_TEST)
+target_compile_definitions(main_test PUBLIC PTUSA_TEST)
 
-#######################################################################################
+###############################################################################
 
-################# project include-paths ###############################################
+################# project include-paths #######################################
 
 set(GENERAL_INCLUDES
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
@@ -325,29 +341,30 @@ if(NOT MINGW)
     target_include_directories(main_perfomance_test PUBLIC ${GENERAL_INCLUDES})
 endif()
 
-#######################################################################################
+###############################################################################
 
-################# set link options ####################################################
-# WARNING: Without --no-undefined the linker will not check, whether all necessary    #
-#          libraries are linked. When a library which is necessary is not linked,     #
-#          the firmware will crash and there will be NO indication why it crashed.    #
-#######################################################################################
+################# set link options ############################################
+# WARNING:                                                                    #
+# Without --no-undefined the linker will not check, whether all necessary     #
+# libraries are linked. When a library which is necessary is not linked,      #
+# the firmware will crash and there will be NO indication why it crashed.     #
+###############################################################################
 if(LINUX)
     target_link_options(${PROJECT_NAME} PRIVATE LINKER:--no-undefined)
 endif()
-#######################################################################################
+###############################################################################
 
 if(ARP_DEVICE)
     set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH $ORIGIN)
 endif()
 
-################# add link targets ####################################################
+################# add link targets ############################################
 if(ARP_DEVICE)
     find_package(ArpDevice REQUIRED)
     find_package(ArpProgramming REQUIRED)
 endif()
 
-################# add link targets ####################################################
+################# add link targets ############################################
 
 target_link_libraries(${PROJECT_NAME} PRIVATE liblua_static toluapp_lib_static zlibstatic fmt::fmt)
 target_link_libraries(libptusa_main toluapp_lib_static zlibstatic fmt::fmt)
@@ -367,7 +384,7 @@ if(USE_OPCUA)
     endif()
 endif()
 
-target_link_libraries(main_test liblua_static toluapp_lib_static zlibstatic gtest gtest_main gmock gmock_main subhook fmt::fmt)
+target_link_libraries(main_test liblua_static toluapp_lib_static zlibstatic GTest::gtest GTest::gmock subhook fmt::fmt)
 
 if(NOT MINGW)
     target_link_libraries(main_perfomance_test liblua_static toluapp_lib_static zlibstatic fmt::fmt benchmark::benchmark)
@@ -385,7 +402,7 @@ elseif (LINUX)
     target_link_libraries(libptusa_main liblua_static)
 endif()
 
-#######################################################################################
+###############################################################################
 if(ARP_DEVICE)
     string(REGEX REPLACE "^.*\\(([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+).*$" "\\1" _ARP_SHORT_DEVICE_VERSION ${ARP_DEVICE_VERSION})
     install(TARGETS ${PROJECT_NAME} libptusa_main PtusaPLCnextEngineer

--- a/test/PAC_dev_lua_tests.cpp
+++ b/test/PAC_dev_lua_tests.cpp
@@ -104,26 +104,28 @@ TEST( toLuapp, tolua_PAC_dev_get_delta_millisec00 )
         "res = get_delta_millisec()" ) );               //Некорректный вызов.
 
     ASSERT_EQ( 0, luaL_dostring( L, "ms = get_millisec()" ) );
+    ASSERT_EQ( 0, luaL_dostring( L, "dt_0 = get_delta_millisec( 0 )" ) );
+    ASSERT_EQ( 0, luaL_dostring( L, "dt_ms = get_delta_millisec( ms )" ) );
+
     lua_getfield( L, LUA_GLOBALSINDEX, "ms" );
     auto ms = tolua_tonumber( L, -1, 0 );
-    lua_remove( L, -1 );   
+    lua_remove( L, -1 );
+    lua_getfield( L, LUA_GLOBALSINDEX, "dt_0" );
+    auto dt_0 = tolua_tonumber( L, -1, 0 );
+    lua_remove( L, -1 );
+    lua_getfield( L, LUA_GLOBALSINDEX, "dt_ms" );
+    auto dt_ms = tolua_tonumber( L, -1, 0 );
+    lua_remove( L, -1 );
 
     // Запрашиваем время, прошедшее с момента 0 - результат должен быть
     // неотрицательным.
-    ASSERT_EQ( 0, luaL_dostring( L, "res = get_delta_millisec( 0 )" ) );
-    lua_getfield( L, LUA_GLOBALSINDEX, "res" );    
-    auto dt1 = tolua_tonumber( L, -1, 0 );
-    EXPECT_GE( dt1, 0 );
-    lua_remove( L, -1 );
-
+    EXPECT_GE( dt_0, 0 );
+    // Запрашиваем время, прошедшее с момента ms - результат должен быть
+    // неотрицательным.
+    EXPECT_GE( dt_ms, 0 );
     // Время должно совпать с расчетным.
-    EXPECT_NEAR( dt1, ms, 1 );
-
-    ASSERT_EQ( 0, luaL_dostring( L, "res = get_delta_millisec( ms )" ) );
-    lua_getfield( L, LUA_GLOBALSINDEX, "res" );
-    auto dt2 = tolua_tonumber( L, -1, 0 );
-    EXPECT_NEAR( dt2, 0, 1 );
-    lua_remove( L, -1 );
+    EXPECT_NEAR( ms, dt_0, 2 );
+    EXPECT_NEAR( dt_ms, 0, 2 );
 
     // Корректная обработка переполнения - результат должен быть положительным
     // и примерно равен UINT32_MAX.
@@ -132,7 +134,7 @@ TEST( toLuapp, tolua_PAC_dev_get_delta_millisec00 )
     lua_getfield( L, LUA_GLOBALSINDEX, "res" );
     auto dt3 = tolua_tonumber( L, -1, 0 );
     EXPECT_GT( dt3, 0 );
-    EXPECT_NEAR( dt3, UINT32_MAX, 10 + 1 );
+    EXPECT_NEAR( dt3, UINT32_MAX, 10 + 2 );
     lua_remove( L, -1 );
 
     lua_close( L );

--- a/test/PAC_info_tests.cpp
+++ b/test/PAC_info_tests.cpp
@@ -28,8 +28,7 @@ class MockOPCUAServer : public OPCUA_server
             }
 
     private:
-        // thread_local для изоляции при параллельном запуске тестов.
-        inline static thread_local MockOPCUAServer* instance = nullptr;
+        inline static thread_local MockOPCUAServer* instance{ nullptr };
     };
 
 TEST( PAC_info, OPCUA_server_start_fail )
@@ -78,9 +77,9 @@ TEST( PAC_info, reset_params )
     }
 
 TEST( PAC_info, save_device )
-    {   
+    {
     io_manager::get_instance()->init( 1 );
-    io_manager::get_instance()->add_node( 0, 
+    io_manager::get_instance()->add_node( 0,
         io_manager::io_node::TYPES::PHOENIX_BK_ETH, 100, "127.0.0.1", "A100",
         0, 0, 0, 0, 0, 0 );
 
@@ -91,43 +90,43 @@ TEST( PAC_info, save_device )
     const auto MAX_SIZE = 1000;
     const auto REF_STR =
         "t.SYSTEM = \n"
-            "\t{\n"
-            "\tRESET_BY=1,\n"
-            "\tUP_DAYS=0,\n"
-            "\tUP_HOURS=0,\n"
-            "\tUP_MINS=0,\n"
-            "\tUP_SECS=0,\n"
-            "\tUP_TIME=\"0 дн. 0:0:0\",\n"
-            "\tCYCLE_TIME=100,\n"
-            "\tWASH_VALVE_SEAT_PERIOD=180,\n"
-            "\tWASH_VALVE_UPPER_SEAT_TIME=2000,\n"
-            "\tWASH_VALVE_LOWER_SEAT_TIME=1000,\n"
-            "\tP_V_OFF_DELAY_TIME=1000,\n"
-            "\tP_V_BOTTOM_ON_DELAY_TIME=1200,\n"
-            "\tP_WAGO_TCP_NODE_WARN_ANSWER_AVG_TIME=50,\n"
-            "\tP_MAIN_CYCLE_WARN_ANSWER_AVG_TIME=300,\n"
-            "\tP_RESTRICTIONS_MODE=0,\n"
-            "\tP_RESTRICTIONS_MANUAL_TIME=120000,\n"
-            "\tP_AUTO_PAUSE_OPER_ON_DEV_ERR=0,\n"
-            "\tCMD=0,\n"
-            "\tCMD_ANSWER=\"\",\n"
-            "\tVERSION=\"" PRODUCT_VERSION_FULL_STR "\",\n"
-            "\tNODEENABLED = \n"
-            "\t{\n"
-            "\t1, \n"
-            "\t},\n"
-            "\tNODEST = \n"
-            "\t{\n"
-            "\t-1, \n"
-            "\t},\n"
-            "\tP_IS_OPC_UA_SERVER_ACTIVE=0,\n"
-            "\tP_IS_OPC_UA_SERVER_CONTROL=0,\n"        
-            "\t}\n";
-    char buff[ MAX_SIZE ] = {0};
+        "\t{\n"
+        "\tRESET_BY=1,\n"
+        "\tUP_DAYS=0,\n"
+        "\tUP_HOURS=0,\n"
+        "\tUP_MINS=0,\n"
+        "\tUP_SECS=0,\n"
+        "\tUP_TIME=\"0 дн. 0:0:0\",\n"
+        "\tCYCLE_TIME=100,\n"
+        "\tWASH_VALVE_SEAT_PERIOD=180,\n"
+        "\tWASH_VALVE_UPPER_SEAT_TIME=2000,\n"
+        "\tWASH_VALVE_LOWER_SEAT_TIME=1000,\n"
+        "\tP_V_OFF_DELAY_TIME=1000,\n"
+        "\tP_V_BOTTOM_ON_DELAY_TIME=1200,\n"
+        "\tP_WAGO_TCP_NODE_WARN_ANSWER_AVG_TIME=50,\n"
+        "\tP_MAIN_CYCLE_WARN_ANSWER_AVG_TIME=300,\n"
+        "\tP_RESTRICTIONS_MODE=0,\n"
+        "\tP_RESTRICTIONS_MANUAL_TIME=120000,\n"
+        "\tP_AUTO_PAUSE_OPER_ON_DEV_ERR=0,\n"
+        "\tCMD=0,\n"
+        "\tCMD_ANSWER=\"\",\n"
+        "\tVERSION=\"" PRODUCT_VERSION_FULL_STR "\",\n"
+        "\tNODEENABLED = \n"
+        "\t{\n"
+        "\t1, \n"
+        "\t},\n"
+        "\tNODEST = \n"
+        "\t{\n"
+        "\t-1, \n"
+        "\t},\n"
+        "\tP_IS_OPC_UA_SERVER_ACTIVE=0,\n"
+        "\tP_IS_OPC_UA_SERVER_CONTROL=0,\n"
+        "\t}\n";
+    char buff[ MAX_SIZE ] = { 0 };
 
     G_PAC_INFO()->reset_uptime();
     G_PAC_INFO()->save_device( buff );
-    EXPECT_STREQ( REF_STR, buff);
+    EXPECT_STREQ( REF_STR, buff );
 
     const auto REF_STR_1s =
         "t.SYSTEM = \n"


### PR DESCRIPTION
Refactors PAC_info class by using in-class member initialization and introduces a dedicated method for resetting uptime, which ensures proper state management.
This addresses potential issues related to uninitialized data and simplifies the process of resetting the uptime.
Mock object lifetime is also fixed in tests.
