### PR TITLE
Changes  `DO`, `AO` devices error on `I/O` node only PP mode activation

### DIFF
--- a/PAC/common/PAC_dev_lua.cpp
+++ b/PAC/common/PAC_dev_lua.cpp
@@ -1,6 +1,6 @@
 /*
 ** Lua binding: PAC_dev
-** Generated automatically by tolua++-1.0.92 on Tue Mar 17 10:34:40 2026.
+** Generated automatically by tolua++-1.0.92 on Tue Apr  7 14:43:30 2026.
 */
 
 #ifndef __cplusplus

--- a/PAC/common/PAC_dev_lua.cpp
+++ b/PAC/common/PAC_dev_lua.cpp
@@ -1,6 +1,6 @@
 /*
 ** Lua binding: PAC_dev
-** Generated automatically by tolua++-1.0.92 on Tue Apr  7 14:43:30 2026.
+** Generated automatically by tolua++-1.0.92 on Tue Mar 17 10:34:40 2026.
 */
 
 #ifndef __cplusplus

--- a/PAC/common/bus_coupler_io.cpp
+++ b/PAC/common/bus_coupler_io.cpp
@@ -790,7 +790,7 @@ void io_device::set_io_vendor( VENDOR vendor )
     this->vendor = vendor;
     }
 //-----------------------------------------------------------------------------
-int io_device::check_output_DO_node_state( u_int index ) const
+int io_device::check_output_DO_node_PP_state( u_int index ) const
     {
     // If no channels configured or tables not initialized, skip node check.
     if ( index >= DO_channels.count || 
@@ -803,10 +803,7 @@ int io_device::check_output_DO_node_state( u_int index ) const
 
     auto io_mgr = G_IO_MANAGER();
     auto node_index = DO_channels.tables[ index ];
-    if ( auto node = io_mgr->get_node( node_index ); 
-        !node->is_active || 
-        node->state != io_manager::io_node::ST_OK ||
-        node->is_pp_mode_active() )
+    if ( auto node = io_mgr->get_node( node_index ); node->is_pp_mode_active() )
         {
         return -1;
         }
@@ -814,7 +811,7 @@ int io_device::check_output_DO_node_state( u_int index ) const
     return 1; // Node is OK.
     }
 //-----------------------------------------------------------------------------
-int io_device::check_output_AO_node_state( u_int index ) const
+int io_device::check_output_AO_node_PP_state( u_int index ) const
     {
     // If no channels configured or tables not initialized, skip node check.
     if ( index >= AO_channels.count || !AO_channels.tables ||
@@ -825,10 +822,7 @@ int io_device::check_output_AO_node_state( u_int index ) const
 
     auto io_mgr = G_IO_MANAGER();
     auto node_index = AO_channels.tables[ index ];
-    if ( auto node = io_mgr->get_node( node_index );
-        !node->is_active ||
-        node->state != io_manager::io_node::ST_OK ||
-        node->is_pp_mode_active() )
+    if ( auto node = io_mgr->get_node( node_index ); node->is_pp_mode_active() )
         {
         return -1;
         }

--- a/PAC/common/bus_coupler_io.h
+++ b/PAC/common/bus_coupler_io.h
@@ -176,9 +176,9 @@ class io_device
         ///
         /// @param index - index of the channel in DO channels table.
         /// 
-        /// @return 1 - node is OK, -1 - node has error or PP mode,
+        /// @return 1 - node is OK, -1 - node has PP mode,
         ///         0 - no output channels configured.
-        int check_output_DO_node_state( u_int index = 0 ) const;
+        int check_output_DO_node_PP_state( u_int index = 0 ) const;
 
         /// @brief Check output AO channel network node state.
         ///
@@ -187,9 +187,9 @@ class io_device
         ///
         /// @param index - index of the channel in AO channels table.
         ///
-        /// @return 1 - node is OK, -1 - node has error or PP mode,
+        /// @return 1 - node is OK, -1 - node has PP mode,
         ///         0 - no output channels configured.
-        int check_output_AO_node_state( u_int index = 0 ) const;
+        int check_output_AO_node_PP_state( u_int index = 0 ) const;
 
 #ifdef PTUSA_TEST
         public:

--- a/PAC/common/device/base.cpp
+++ b/PAC/common/device/base.cpp
@@ -558,33 +558,23 @@ AO1::AO1( const char* dev_name,
     device::DEVICE_TYPE type,
     device::DEVICE_SUB_TYPE sub_type,
     u_int par_cnt ) :
-    analog_io_device( dev_name, type, sub_type,
-        par_cnt + ADDITIONAL_PARAMS_COUNT - 1 )
+    analog_io_device( dev_name, type, sub_type, par_cnt )
     {
-    set_par_name( P_DT, 0, "P_DT" );
-    }
-//-----------------------------------------------------------------------------
-int AO1::get_params_count() const
-    {
-    return ADDITIONAL_PARAMS_COUNT - 1;
     }
 //-----------------------------------------------------------------------------
 void AO1::evaluate_io()
     {
-    current_state = analog_io_device::get_state();
-
-    // Check if the network node for output channel is available.
-    if ( auto node_state = check_output_AO_node_state(); node_state < 0 )
+    if ( G_PAC_INFO()->is_emulator() )
         {
-        auto dt = static_cast<u_int_4>( get_par( P_DT, 0 ) );
-        if ( get_delta_millisec( state_change_time ) >= dt )
-            {
-            current_state = -1;
-            }
+        // Ничего не делаем.
+        return;
         }
-    else
+
+    current_state = analog_io_device::get_state();
+    // Check if the network node for output channel is available.
+    if ( auto node_state = check_output_AO_node_PP_state(); node_state < 0 )
         {
-        state_change_time = get_millisec();
+        current_state = -1;
         }
     }
 //-----------------------------------------------------------------------------

--- a/PAC/common/device/base.cpp
+++ b/PAC/common/device/base.cpp
@@ -558,8 +558,16 @@ AO1::AO1( const char* dev_name,
     device::DEVICE_TYPE type,
     device::DEVICE_SUB_TYPE sub_type,
     u_int par_cnt ) :
-    analog_io_device( dev_name, type, sub_type, par_cnt )
+    analog_io_device( dev_name, type, sub_type,
+        par_cnt + ADDITIONAL_PARAMS_COUNT - 1 )
     {
+    set_par_name( P_DT, 0, "P_DT" );
+    direct_set_state( 1 );
+    }
+//-----------------------------------------------------------------------------
+int AO1::get_params_count() const
+    {
+    return ADDITIONAL_PARAMS_COUNT - 1;
     }
 //-----------------------------------------------------------------------------
 int AO1::get_state() const
@@ -569,10 +577,19 @@ int AO1::get_state() const
     // Check if the network node for output channel is available.
     if ( auto node_state = check_output_AO_node_state(); node_state < 0 )
         {
-        return -1; // Node error or PP mode.
+        auto dt = static_cast<u_int_4>( get_par( P_DT, 0 ) );
+        if ( get_delta_millisec( state_change_time ) >= dt )
+            {
+            current_state = -1;
+            }
+        }
+    else
+        {
+        state_change_time = get_millisec();
+        current_state = analog_io_device::get_state();
         }
 
-    return analog_io_device::get_state();
+    return current_state;
     }
 //-----------------------------------------------------------------------------
 float AO1::get_value() const

--- a/PAC/common/device/base.cpp
+++ b/PAC/common/device/base.cpp
@@ -562,7 +562,6 @@ AO1::AO1( const char* dev_name,
         par_cnt + ADDITIONAL_PARAMS_COUNT - 1 )
     {
     set_par_name( P_DT, 0, "P_DT" );
-    direct_set_state( 1 );
     }
 //-----------------------------------------------------------------------------
 int AO1::get_params_count() const

--- a/PAC/common/device/base.cpp
+++ b/PAC/common/device/base.cpp
@@ -574,6 +574,8 @@ int AO1::get_state() const
     {
     if ( G_PAC_INFO()->is_emulator() ) return analog_io_device::get_state();
 
+    current_state = analog_io_device::get_state();
+
     // Check if the network node for output channel is available.
     if ( auto node_state = check_output_AO_node_state(); node_state < 0 )
         {
@@ -586,7 +588,6 @@ int AO1::get_state() const
     else
         {
         state_change_time = get_millisec();
-        current_state = analog_io_device::get_state();
         }
 
     return current_state;

--- a/PAC/common/device/base.cpp
+++ b/PAC/common/device/base.cpp
@@ -569,10 +569,8 @@ int AO1::get_params_count() const
     return ADDITIONAL_PARAMS_COUNT - 1;
     }
 //-----------------------------------------------------------------------------
-int AO1::get_state() const
+void AO1::evaluate_io()
     {
-    if ( G_PAC_INFO()->is_emulator() ) return analog_io_device::get_state();
-
     current_state = analog_io_device::get_state();
 
     // Check if the network node for output channel is available.
@@ -588,6 +586,11 @@ int AO1::get_state() const
         {
         state_change_time = get_millisec();
         }
+    }
+//-----------------------------------------------------------------------------
+int AO1::get_state() const
+    {
+    if ( G_PAC_INFO()->is_emulator() ) return analog_io_device::get_state();
 
     return current_state;
     }

--- a/PAC/common/device/base.h
+++ b/PAC/common/device/base.h
@@ -659,8 +659,6 @@ class AO1 : public analog_io_device
         float get_value() const override;
         void  direct_set_value( float new_value ) override;
 
-        virtual int get_params_count() const;
-        
         void evaluate_io() override;
 
         enum CONSTANTS
@@ -670,14 +668,6 @@ class AO1 : public analog_io_device
 
     private:
         mutable int current_state{};
-        mutable uint32_t state_change_time{ get_millisec() };
-
-        enum PARAMS
-            {
-            P_DT = 1,
-
-            ADDITIONAL_PARAMS_COUNT,
-            };
     };
 //-----------------------------------------------------------------------------
 /// @brief Виртуальное устройство без привязки к модулям ввода-вывода

--- a/PAC/common/device/base.h
+++ b/PAC/common/device/base.h
@@ -668,7 +668,7 @@ class AO1 : public analog_io_device
 
     private:
         mutable int current_state{};
-        mutable uint32_t state_change_time{};
+        mutable uint32_t state_change_time{ get_millisec() };
 
         enum PARAMS
             {

--- a/PAC/common/device/base.h
+++ b/PAC/common/device/base.h
@@ -660,6 +660,8 @@ class AO1 : public analog_io_device
         void  direct_set_value( float new_value ) override;
 
         virtual int get_params_count() const;
+        
+        void evaluate_io() override;
 
         enum CONSTANTS
             {

--- a/PAC/common/device/base.h
+++ b/PAC/common/device/base.h
@@ -667,7 +667,7 @@ class AO1 : public analog_io_device
             };
 
     private:
-        mutable int current_state{};
+        mutable int current_state{ 1 };
         mutable uint32_t state_change_time{};
 
         enum PARAMS

--- a/PAC/common/device/base.h
+++ b/PAC/common/device/base.h
@@ -667,7 +667,7 @@ class AO1 : public analog_io_device
             };
 
     private:
-        mutable int current_state{ 1 };
+        mutable int current_state{};
         mutable uint32_t state_change_time{};
 
         enum PARAMS

--- a/PAC/common/device/base.h
+++ b/PAC/common/device/base.h
@@ -659,10 +659,22 @@ class AO1 : public analog_io_device
         float get_value() const override;
         void  direct_set_value( float new_value ) override;
 
-    protected:
+        virtual int get_params_count() const;
+
         enum CONSTANTS
             {
             AO_INDEX = 0,   ///< Индекс канала аналогового выхода.
+            };
+
+    private:
+        mutable int current_state{};
+        mutable uint32_t state_change_time{};
+
+        enum PARAMS
+            {
+            P_DT = 1,
+
+            ADDITIONAL_PARAMS_COUNT,
             };
     };
 //-----------------------------------------------------------------------------

--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -32,11 +32,6 @@ signal_column_iolink::out_data signal_column_iolink::stub_out_info{};
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-int DO1::get_params_count() const
-    {
-    return ADDITIONAL_PARAMS_COUNT - 1;
-    }
-//-----------------------------------------------------------------------------
 int DO1::get_state() const
     {
     if ( G_PAC_INFO()->is_emulator() ) return digital_io_device::get_state();

--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -36,23 +36,22 @@ int DO1::get_state() const
     {
     if ( G_PAC_INFO()->is_emulator() ) return digital_io_device::get_state();
 
-    current_state = get_DO( DO_INDEX );
-
-    // Check if the network node for output channel is available.
-    if ( auto node_state = check_output_DO_node_state(); node_state < 0 )
-        {
-        auto dt = static_cast<u_int_4>( get_par( P_DT, 0 ) );
-        if ( get_delta_millisec( state_change_time ) >= dt )
-            {
-            current_state = -1;
-            }
-        }
-    else
-        {
-        state_change_time = get_millisec();        
-        }
-
     return current_state;
+    }
+//-----------------------------------------------------------------------------
+void DO1::evaluate_io()
+    {
+    if ( G_PAC_INFO()->is_emulator() )
+        {
+        // Ничего не делаем.
+        return;
+        }
+
+    current_state = get_DO( DO_INDEX );
+    if ( auto node_state = check_output_DO_node_PP_state(); node_state < 0 )
+        {
+        current_state = -1;
+        }
     }
 //-----------------------------------------------------------------------------
 void DO1::direct_on()
@@ -4069,19 +4068,18 @@ virtual_device::virtual_device( const char *dev_name,
 analog_output::analog_output( const char* dev_name ) :
     AO1( dev_name, DT_AO, DST_NONE, ADDITIONAL_PARAM_COUNT )
     {
-    start_param_idx = AO1::get_params_count();
-    set_par_name( P_MIN_VALUE, start_param_idx, "P_MIN_V" );
-    set_par_name( P_MAX_VALUE, start_param_idx, "P_MAX_V" );
+    set_par_name( P_MIN_VALUE, 0, "P_MIN_V" );
+    set_par_name( P_MAX_VALUE, 0, "P_MAX_V" );
     }
 //-----------------------------------------------------------------------------
 float analog_output::get_min_value() const
     {
-    return get_par( P_MIN_VALUE, start_param_idx );
+    return get_par( P_MIN_VALUE, 0 );
     }
 //-----------------------------------------------------------------------------
 float analog_output::get_max_value() const
     {
-    return get_par( P_MAX_VALUE, start_param_idx );
+    return get_par( P_MAX_VALUE, 0 );
     }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------

--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -32,6 +32,11 @@ signal_column_iolink::out_data signal_column_iolink::stub_out_info{};
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
+int DO1::get_params_count() const
+    {
+    return ADDITIONAL_PARAMS_COUNT - 1;
+    }
+//-----------------------------------------------------------------------------
 int DO1::get_state() const
     {
     if ( G_PAC_INFO()->is_emulator() ) return digital_io_device::get_state();
@@ -1767,15 +1772,15 @@ int DI1::get_state() const
         {
         if ( current_state != get_DI( DI_INDEX ) )
             {
-            if ( get_delta_millisec( time ) > dt )
+            if ( get_delta_millisec( state_change_time ) > dt )
                 {
                 current_state = get_DI( DI_INDEX );
-                time = get_millisec();
+                state_change_time = get_millisec();
                 }
             }
         else
             {
-            time = get_millisec();
+            state_change_time = get_millisec();
             }
         }
     else current_state = get_DI( DI_INDEX );
@@ -4056,18 +4061,19 @@ virtual_device::virtual_device( const char *dev_name,
 analog_output::analog_output( const char* dev_name ) :
     AO1( dev_name, DT_AO, DST_NONE, ADDITIONAL_PARAM_COUNT )
     {
-    set_par_name( P_MIN_VALUE, 0, "P_MIN_V" );
-    set_par_name( P_MAX_VALUE, 0, "P_MAX_V" );
+    start_param_idx = AO1::get_params_count();
+    set_par_name( P_MIN_VALUE, start_param_idx, "P_MIN_V" );
+    set_par_name( P_MAX_VALUE, start_param_idx, "P_MAX_V" );
     }
 //-----------------------------------------------------------------------------
 float analog_output::get_min_value() const
     {
-    return get_par( P_MIN_VALUE, 0 );
+    return get_par( P_MIN_VALUE, start_param_idx );
     }
 //-----------------------------------------------------------------------------
 float analog_output::get_max_value() const
     {
-    return get_par( P_MAX_VALUE, 0 );
+    return get_par( P_MAX_VALUE, start_param_idx );
     }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------

--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -41,13 +41,23 @@ int DO1::get_state() const
     {
     if ( G_PAC_INFO()->is_emulator() ) return digital_io_device::get_state();
 
+    current_state = get_DO( DO_INDEX );
+
     // Check if the network node for output channel is available.
     if ( auto node_state = check_output_DO_node_state(); node_state < 0 )
         {
-        return -1; // Node error or PP mode.
+        auto dt = static_cast<u_int_4>( get_par( P_DT, 0 ) );
+        if ( get_delta_millisec( state_change_time ) >= dt )
+            {
+            current_state = -1;
+            }
+        }
+    else
+        {
+        state_change_time = get_millisec();        
         }
 
-    return get_DO( DO_INDEX );
+    return current_state;
     }
 //-----------------------------------------------------------------------------
 void DO1::direct_on()

--- a/PAC/common/device/device.cpp
+++ b/PAC/common/device/device.cpp
@@ -1769,10 +1769,8 @@ void DI1::direct_off()
     if ( G_PAC_INFO()->is_emulator() ) return digital_io_device::direct_off();
     }
 //-----------------------------------------------------------------------------
-int DI1::get_state() const
+void DI1::evaluate_io()
     {
-    if ( G_PAC_INFO()->is_emulator() ) return digital_io_device::get_state();
-
     if ( auto dt = static_cast<u_int_4>( get_par( P_DT, 0 ) ); dt > 0 )
         {
         if ( current_state != get_DI( DI_INDEX ) )
@@ -1789,6 +1787,11 @@ int DI1::get_state() const
             }
         }
     else current_state = get_DI( DI_INDEX );
+    }
+//-----------------------------------------------------------------------------
+int DI1::get_state() const
+    {
+    if ( G_PAC_INFO()->is_emulator() ) return digital_io_device::get_state();
 
     return current_state;
     }

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -49,26 +49,18 @@ class DO1 : public digital_io_device
     public:
         DO1( const char* dev_name, device::DEVICE_TYPE type,
             device::DEVICE_SUB_TYPE sub_type ) :
-            digital_io_device( dev_name, type, sub_type,
-                ADDITIONAL_PARAMS_COUNT - 1 )
+            digital_io_device( dev_name, type, sub_type, 0 )
             {
-            set_par_name( P_DT, 0, "P_DT" );
             }
 
         int  get_state() const override;
         void direct_on() override;
         void direct_off() override;
 
+        void evaluate_io() override;
+
     private:
         mutable int current_state{};
-        mutable uint32_t state_change_time{ get_millisec() };
-
-        enum PARAMS
-            {
-            P_DT = 1,
-
-            ADDITIONAL_PARAMS_COUNT,
-            };
 
         enum CONSTANTS
             {

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -63,7 +63,7 @@ class DO1 : public digital_io_device
 
     private:
         mutable int current_state{};
-        mutable uint32_t state_change_time{};
+        mutable uint32_t state_change_time{ get_millisec() };
 
         enum PARAMS
             {
@@ -930,7 +930,7 @@ class DI1 : public digital_io_device
 
     private:
         mutable int current_state;
-        mutable uint32_t state_change_time{};
+        mutable uint32_t state_change_time{ get_millisec() };
 
         enum CONSTANTS
             {

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -59,8 +59,6 @@ class DO1 : public digital_io_device
         void direct_on() override;
         void direct_off() override;
 
-        virtual int get_params_count() const;
-
     private:
         mutable int current_state{};
         mutable uint32_t state_change_time{ get_millisec() };

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -47,17 +47,31 @@
 class DO1 : public digital_io_device
     {
     public:
-        DO1( const char *dev_name, device::DEVICE_TYPE type,
-            device::DEVICE_SUB_TYPE sub_type ):
-        digital_io_device( dev_name, type, sub_type, 0 )
+        DO1( const char* dev_name, device::DEVICE_TYPE type,
+            device::DEVICE_SUB_TYPE sub_type ) :
+            digital_io_device( dev_name, type, sub_type,
+                ADDITIONAL_PARAMS_COUNT - 1 )
             {
+            set_par_name( P_DT, 0, "P_DT" );
             }
 
         int  get_state() const override;
         void direct_on() override;
         void direct_off() override;
 
+        virtual int get_params_count() const;
+
     private:
+        mutable int current_state{};
+        mutable uint32_t state_change_time{};
+
+        enum PARAMS
+            {
+            P_DT = 1,
+
+            ADDITIONAL_PARAMS_COUNT,
+            };
+
         enum CONSTANTS
             {
             DO_INDEX = 0,   ///< Индекс канала дискретного выхода.
@@ -887,6 +901,8 @@ class analog_output : public AO1
         float get_max_value() const override;
 
     private:
+        u_int start_param_idx;
+
         enum CONSTANTS
             {
             ADDITIONAL_PARAM_COUNT = 2,
@@ -914,7 +930,7 @@ class DI1 : public digital_io_device
 
     private:
         mutable int current_state;
-        mutable uint32_t time = 0;
+        mutable uint32_t state_change_time{};
 
         enum CONSTANTS
             {

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -891,8 +891,6 @@ class analog_output : public AO1
         float get_max_value() const override;
 
     private:
-        u_int start_param_idx;
-
         enum CONSTANTS
             {
             ADDITIONAL_PARAM_COUNT = 2,

--- a/PAC/common/device/device.h
+++ b/PAC/common/device/device.h
@@ -926,6 +926,8 @@ class DI1 : public digital_io_device
 
         int get_state() const override;
 
+        void evaluate_io() override;
+
     private:
         mutable int current_state;
         mutable uint32_t state_change_time{ get_millisec() };

--- a/PAC/common/device/valve.cpp
+++ b/PAC/common/device/valve.cpp
@@ -2682,12 +2682,13 @@ analog_valve_iolink::analog_valve_iolink( const char* dev_name ) : AO1(
     dev_name, DT_VC, DST_VC_IOLINK, 
     static_cast<int>( PAR_CONSTANTS::ADDITIONAL_PARAMS_COUNT ) - 1 )
     {
+    start_param_idx = AO1::get_params_count();
     in_info.closed = true;
     in_info.opened = false;
 
     auto fb_par_idx = static_cast<int>( PAR_CONSTANTS::P_FB );
-    set_par_name( fb_par_idx, 0, "P_FB" );
-    set_par( fb_par_idx, 0, 1.0f );
+    set_par_name( fb_par_idx, start_param_idx, "P_FB" );
+    set_par( fb_par_idx, start_param_idx, 1.0f );
     }
 //-----------------------------------------------------------------------------
 void analog_valve_iolink::evaluate_io()
@@ -2793,7 +2794,7 @@ int analog_valve_iolink::get_state() const
         error_id != io_device::IOLINKSTATE::OK )
         {
         // Проверяем параметр P_FB для возможности отключения ошибок устройства.
-        if ( get_par(
+        if ( get_par( start_param_idx +
             static_cast<int>( analog_valve_iolink::PAR_CONSTANTS::P_FB ), 0 ) == 0 )
             {
             return 1; // Обратная связь отключена - нет ошибок.

--- a/PAC/common/device/valve.cpp
+++ b/PAC/common/device/valve.cpp
@@ -2682,13 +2682,12 @@ analog_valve_iolink::analog_valve_iolink( const char* dev_name ) : AO1(
     dev_name, DT_VC, DST_VC_IOLINK, 
     static_cast<int>( PAR_CONSTANTS::ADDITIONAL_PARAMS_COUNT ) - 1 )
     {
-    start_param_idx = AO1::get_params_count();
     in_info.closed = true;
     in_info.opened = false;
 
     auto fb_par_idx = static_cast<int>( PAR_CONSTANTS::P_FB );
-    set_par_name( fb_par_idx, start_param_idx, "P_FB" );
-    set_par( fb_par_idx, start_param_idx, 1.0f );
+    set_par_name( fb_par_idx, 0, "P_FB" );
+    set_par( fb_par_idx, 0, 1.0f );
     }
 //-----------------------------------------------------------------------------
 void analog_valve_iolink::evaluate_io()
@@ -2794,9 +2793,8 @@ int analog_valve_iolink::get_state() const
         error_id != io_device::IOLINKSTATE::OK )
         {
         // Проверяем параметр P_FB для возможности отключения ошибок устройства.
-        if ( get_par( 
-            static_cast<int>( analog_valve_iolink::PAR_CONSTANTS::P_FB ),
-            start_param_idx ) == 0 )
+        if ( get_par( static_cast<int>( 
+            analog_valve_iolink::PAR_CONSTANTS::P_FB ), 0 ) == 0 )
             {
             return 1; // Обратная связь отключена - нет ошибок.
             }

--- a/PAC/common/device/valve.cpp
+++ b/PAC/common/device/valve.cpp
@@ -2794,8 +2794,9 @@ int analog_valve_iolink::get_state() const
         error_id != io_device::IOLINKSTATE::OK )
         {
         // Проверяем параметр P_FB для возможности отключения ошибок устройства.
-        if ( get_par( start_param_idx +
-            static_cast<int>( analog_valve_iolink::PAR_CONSTANTS::P_FB ), 0 ) == 0 )
+        if ( get_par( 
+            static_cast<int>( analog_valve_iolink::PAR_CONSTANTS::P_FB ),
+            start_param_idx ) == 0 )
             {
             return 1; // Обратная связь отключена - нет ошибок.
             }

--- a/PAC/common/device/valve.h
+++ b/PAC/common/device/valve.h
@@ -1221,7 +1221,6 @@ class analog_valve_iolink : public AO1
 #ifndef PTUSA_TEST
     private:
 #endif // !PTUSA_TEST
-        u_int start_param_idx;
 
 #pragma pack(push,1)
         struct in_data

--- a/PAC/common/device/valve.h
+++ b/PAC/common/device/valve.h
@@ -1218,7 +1218,11 @@ class analog_valve_iolink : public AO1
             ADDITIONAL_PARAMS_COUNT, ///Количество дополнительных параметров.
             };
 
+#ifndef PTUSA_TEST
     private:
+#endif // !PTUSA_TEST
+        u_int start_param_idx;
+
 #pragma pack(push,1)
         struct in_data
             {

--- a/test/bus_coupler_io_tests.cpp
+++ b/test/bus_coupler_io_tests.cpp
@@ -246,18 +246,18 @@ TEST( io_node, get_display_state_all_node_types )
     G_PAC_INFO()->emulation_on();
 	}
 
-TEST( io_device, check_output_DO_node_state )
+TEST( io_device, check_output_DO_node_PP_state )
 	{
 	io_device dev( "TEST_DO" );
-    EXPECT_EQ( 0, dev.check_output_DO_node_state() );
+    EXPECT_EQ( 0, dev.check_output_DO_node_PP_state() );
 
 	dev.init_and_alloc( 1, 0, 0, 0 );
 
 	io_manager::get_instance()->init( 0 );
-	EXPECT_EQ( -1, dev.check_output_DO_node_state() );
+	EXPECT_EQ( 1, dev.check_output_DO_node_PP_state() );
 
 	io_manager::get_instance()->init( 1 );
-	EXPECT_EQ( -1, dev.check_output_DO_node_state() );
+	EXPECT_EQ( 1, dev.check_output_DO_node_PP_state() );
 
 	io_manager::get_instance()->add_node( 0,
 		io_manager::io_node::PHOENIX_BK_ETH, 1, "127.0.0.1",
@@ -269,37 +269,37 @@ TEST( io_device, check_output_DO_node_state )
 	node->state = io_manager::io_node::ST_OK;
 	node->status_register = 0;
 	G_PAC_INFO()->emulation_off();
-	EXPECT_EQ( 1, dev.check_output_DO_node_state() );
+	EXPECT_EQ( 1, dev.check_output_DO_node_PP_state() );
 
     node->status_register = 0x0001;  // Non-PP warning bit.
-    EXPECT_EQ( 1, dev.check_output_DO_node_state() );
+    EXPECT_EQ( 1, dev.check_output_DO_node_PP_state() );
 
 	node->status_register = 0x0010;  // PP mode.
-	EXPECT_EQ( -1, dev.check_output_DO_node_state() );
+	EXPECT_EQ( -1, dev.check_output_DO_node_PP_state() );
 
 	node->state = io_manager::io_node::ST_NO_CONNECT;
-	EXPECT_EQ( -1, dev.check_output_DO_node_state() );
+	EXPECT_EQ( -1, dev.check_output_DO_node_PP_state() );
 	
 	node->is_active = false;
 	node->state = io_manager::io_node::ST_OK;
 	node->status_register = 0;
-	EXPECT_EQ( -1, dev.check_output_DO_node_state() );
+	EXPECT_EQ( 1, dev.check_output_DO_node_PP_state() );
 
 	G_PAC_INFO()->emulation_on();
 	}
 
-TEST( io_device, check_output_AO_node_state )
+TEST( io_device, check_output_AO_node_PP_state )
     {
     io_device dev( "TEST_AO" );
-    EXPECT_EQ( 0, dev.check_output_AO_node_state() );
+    EXPECT_EQ( 0, dev.check_output_AO_node_PP_state() );
 
     dev.init_and_alloc( 0, 0, 1, 0 );
 
     io_manager::get_instance()->init( 0 );
-    EXPECT_EQ( -1, dev.check_output_AO_node_state() );
+    EXPECT_EQ( 1, dev.check_output_AO_node_PP_state() );
 
     io_manager::get_instance()->init( 1 );
-    EXPECT_EQ( -1, dev.check_output_AO_node_state() );
+    EXPECT_EQ( 1, dev.check_output_AO_node_PP_state() );
 
     io_manager::get_instance()->add_node( 0,
         io_manager::io_node::PHOENIX_BK_ETH, 1, "127.0.0.1",
@@ -311,21 +311,21 @@ TEST( io_device, check_output_AO_node_state )
     node->state = io_manager::io_node::ST_OK;
     node->status_register = 0;
     G_PAC_INFO()->emulation_off();
-    EXPECT_EQ( 1, dev.check_output_AO_node_state() );
+    EXPECT_EQ( 1, dev.check_output_AO_node_PP_state() );
 
     node->status_register = 0x0001;  // Non-PP warning bit.
-    EXPECT_EQ( 1, dev.check_output_AO_node_state() );
+    EXPECT_EQ( 1, dev.check_output_AO_node_PP_state() );
 
     node->status_register = 0x0010;  // PP mode.
-    EXPECT_EQ( -1, dev.check_output_AO_node_state() );
+    EXPECT_EQ( -1, dev.check_output_AO_node_PP_state() );
 
     node->state = io_manager::io_node::ST_NO_CONNECT;
-    EXPECT_EQ( -1, dev.check_output_AO_node_state() );
+    EXPECT_EQ( -1, dev.check_output_AO_node_PP_state() );
 
     node->is_active = false;
     node->state = io_manager::io_node::ST_OK;
     node->status_register = 0;
-    EXPECT_EQ( -1, dev.check_output_AO_node_state() );
+    EXPECT_EQ( 1, dev.check_output_AO_node_PP_state() );
 
     G_PAC_INFO()->emulation_on();
     }

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -1641,6 +1641,20 @@ TEST( DO1, set_cmd )
     EXPECT_EQ( do1.get_state(), 1 );
     }
 
+TEST( DO1, save_device )
+    {
+    DO1 do1( "DO1", device::DEVICE_TYPE::DT_DO, device::DEVICE_SUB_TYPE::DST_DO );
+    const int BUFF_SIZE = 200;
+    std::array <char, BUFF_SIZE> buff{};
+
+    do1.save_device( buff.data() );
+    EXPECT_STREQ( "DO1={M=0, ST=0, P_DT=0},\n", buff.data() );
+
+    do1.set_cmd( "P_DT", 0, 100.1f );
+    do1.save_device( buff.data() );
+    EXPECT_STREQ( "DO1={M=0, ST=0, P_DT=100.10},\n", buff.data() );
+    }
+
 
 TEST( AI1, get_max_val )
     {
@@ -2086,6 +2100,18 @@ TEST( analog_output, get_value )
     io_manager::replace_instance( prev_mngr );
     }
 
+TEST( analog_output, save_device )
+    {
+    analog_output AO01( "AO1" );
+    const int BUFF_SIZE = 200;
+    std::array <char, BUFF_SIZE> buff{};
+
+    AO01.save_device( buff.data() );
+    EXPECT_STREQ( "AO1={M=0, V=0, E=0, M_EXP=1.0, S_DEV=0.2, "
+        "P_DT=0, P_MIN_V=0, P_MAX_V=0},\n",
+        buff.data() );
+    }
+
 
 TEST( flow_s, flow_s )
     {
@@ -2161,7 +2187,7 @@ TEST( DO_signal, DO_signal )
     DO_signal DO1( "DO1" );
 
     DO1.save_device( buff );
-    EXPECT_STREQ( "DO1={M=0, ST=0},\n", buff );
+    EXPECT_STREQ( "DO1={M=0, ST=0, P_DT=0},\n", buff );
     }
 
 TEST( DO_signal, get_type_name )
@@ -2178,7 +2204,7 @@ TEST( siren, siren )
     siren S1( "S1" );
 
     S1.save_device( buff );
-    EXPECT_STREQ( "S1={M=0, ST=0},\n", buff );
+    EXPECT_STREQ( "S1={M=0, ST=0, P_DT=0},\n", buff );
     }
 
 TEST( siren, get_type_name )
@@ -2195,7 +2221,7 @@ TEST( lamp, lamp )
     lamp L1( "L1" );
 
     L1.save_device( buff );
-    EXPECT_STREQ( "L1={M=0, ST=0},\n", buff );
+    EXPECT_STREQ( "L1={M=0, ST=0, P_DT=0},\n", buff );
     }
 
 TEST( lamp, get_type_name )
@@ -2693,6 +2719,23 @@ TEST( valve_mix_proof, direct_set_state )
     }
 
 
+TEST( analog_valve, save_device )
+    {
+    analog_valve vc1( "VC1" );
+    const int BUFF_SIZE = 200;
+    std::array <char, BUFF_SIZE> buff{};
+
+    vc1.save_device( buff.data() );
+    EXPECT_STREQ( "VC1={M=0, ST=1, V=0, E=0, M_EXP=1.0, S_DEV=0.2, P_DT=0},\n",
+        buff.data() );
+
+    vc1.set_cmd( "P_DT", 0, 100.1f );
+    vc1.save_device( buff.data() );
+    EXPECT_STREQ( "VC1={M=0, ST=1, V=0, E=0, M_EXP=1.0, S_DEV=0.2, "
+        "P_DT=100.10},\n",
+        buff.data() );
+    }
+
 TEST( analog_valve, get_min_value )
     {
     const analog_valve VC1( "VC1" );
@@ -2786,7 +2829,7 @@ TEST_F( analog_valve_test, io_modules_direct_on_off )
     {
     // По умолчанию 0%.
     EXPECT_FLOAT_EQ( 0.0f, VC1.get_value() );
-    EXPECT_EQ( 0, VC1.get_state() );
+    EXPECT_EQ( 1, VC1.get_state() );
 
     // direct_on -> 100%
     VC1.direct_on();
@@ -4071,7 +4114,8 @@ TEST( analog_valve_iolink, analog_valve_iolink )
     char buff[ BUFF_SIZE ] = { 0 };
     V1.save_device( buff );
     EXPECT_STREQ(
-        "V1={M=0, ST=0, V=0, NAMUR_ST=0, OPENED=0, CLOSED=1, BLINK=0, P_FB=1},\n",
+        "V1={M=0, ST=1, V=0, NAMUR_ST=0, OPENED=0, CLOSED=1, BLINK=0, "
+        "P_DT=0, P_FB=1},\n",
         buff );
     }
 
@@ -6821,7 +6865,8 @@ TEST_F( iolink_dev_test, analog_valve_iolink_get_state_respects_P_FB )
 
     // Отключаем обратную связь (P_FB=0) — ошибки устройства игнорируются,
     // get_state() должен вернуть 1.
-    VC1.set_par( static_cast<int>( analog_valve_iolink::PAR_CONSTANTS::P_FB ),
+    VC1.set_par( VC1.start_param_idx +
+        static_cast<int>( analog_valve_iolink::PAR_CONSTANTS::P_FB ),
         0, 0.0f );
     VC1.evaluate_io();
     EXPECT_EQ( VC1.get_state(), 1 );

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -6898,9 +6898,8 @@ TEST_F( iolink_dev_test, analog_valve_iolink_get_state_respects_P_FB )
 
     // Отключаем обратную связь (P_FB=0) — ошибки устройства игнорируются,
     // get_state() должен вернуть 1.
-    VC1.set_par( VC1.start_param_idx +
-        static_cast<int>( analog_valve_iolink::PAR_CONSTANTS::P_FB ),
-        0, 0.0f );
+    VC1.set_par( static_cast<int>( analog_valve_iolink::PAR_CONSTANTS::P_FB ),
+        VC1.start_param_idx, 0.0f );
     VC1.evaluate_io();
     EXPECT_EQ( VC1.get_state(), 1 );
 

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -1613,6 +1613,13 @@ TEST( DO1, get_state )
     EXPECT_EQ( do1.get_state(), 1 );
     EXPECT_EQ( do1.DO_channels.char_write_values[ 0 ][ 0 ], 1 );
 
+    auto node = mngr.get_node( 0 );
+    node->status_register = 0x0010; // PP mode.
+    EXPECT_EQ( do1.get_state(), -1 );
+
+    do1.set_cmd( "P_DT", 0, 1000.0f );
+    EXPECT_EQ( do1.get_state(), 1 );
+
     io_manager::replace_instance( prev_mngr );
     G_PAC_INFO()->emulation_on();
 
@@ -2157,6 +2164,10 @@ TEST( DI_signal, get_state )
     EXPECT_EQ( DI1.get_state(), 0 );
 
     *DI1.DI_channels.char_read_values[ 0 ] = 1;
+    EXPECT_EQ( DI1.get_state(), 1 );
+
+    *DI1.DI_channels.char_read_values[ 0 ] = 0;
+    DI1.set_cmd( "P_DT", 0, 1000.0f );
     EXPECT_EQ( DI1.get_state(), 1 );
 
     G_PAC_INFO()->emulation_on();

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -2168,7 +2168,17 @@ TEST( DI_signal, get_state )
 
     *DI1.DI_channels.char_read_values[ 0 ] = 0;
     DI1.set_cmd( "P_DT", 0, 1000.0f );
+    // Область чтения изменилась, но не прошло заданное время - состояние не
+    // должно изменяться.
     EXPECT_EQ( DI1.get_state(), 1 );
+
+    DeltaMilliSecSubHooker::set_millisec( 1010UL );
+    // Прошло заданное время - состояние должно измениться.
+    EXPECT_EQ( DI1.get_state(), 0 );
+
+    // Область чтения не изменилась - состояние не должно изменяться.
+    EXPECT_EQ( DI1.get_state(), 0 );
+    DeltaMilliSecSubHooker::set_default_time();
 
     G_PAC_INFO()->emulation_on();
     }

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -1595,7 +1595,7 @@ TEST( DO1, get_state )
 
     G_PAC_INFO()->emulation_off();
     // Когда отключена эмуляция, пишем в буфер обмена с модулями ввода\вывода.
-    EXPECT_EQ( do1.get_state(), -1 );
+    EXPECT_EQ( do1.get_state(), 0 );
     EXPECT_EQ( do1.DO_channels.char_write_values[ 0 ][ 0 ], 0 );
 
     uni_io_manager mngr;
@@ -1605,27 +1605,24 @@ TEST( DO1, get_state )
         1, "127.0.0.1", "A100", 1, 1, 1, 1, 1, 1 );
     do1.init_channel( io_device::IO_channels::CT_DO, 0, 0, 0 );
 
-    EXPECT_EQ( do1.get_state(), -1 );
+    EXPECT_EQ( do1.get_state(), 0 );
 
     do1.on();
     mngr.get_node( 0 )->is_active = true;
     mngr.get_node( 0 )->state = io_manager::io_node::STATES::ST_OK;
+    do1.evaluate_io();
     EXPECT_EQ( do1.get_state(), 1 );
     EXPECT_EQ( do1.DO_channels.char_write_values[ 0 ][ 0 ], 1 );
 
     auto node = mngr.get_node( 0 );
     node->status_register = 0x0010; // PP mode.
-    DeltaMilliSecSubHooker::set_millisec( 0 );
+    do1.evaluate_io();
     EXPECT_EQ( do1.get_state(), -1 );
 
-    do1.set_cmd( "P_DT", 0, 1000.0f );
-    EXPECT_EQ( do1.get_state(), 1 );
-    DeltaMilliSecSubHooker::set_millisec( 1001 );
-
+    do1.evaluate_io();
     EXPECT_EQ( node->status_register, 0x0010 );
     EXPECT_EQ( do1.get_state(), -1 );
 
-    DeltaMilliSecSubHooker::set_default_time();
     io_manager::replace_instance( prev_mngr );
     G_PAC_INFO()->emulation_on();
 
@@ -1661,11 +1658,11 @@ TEST( DO1, save_device )
     std::array <char, BUFF_SIZE> buff{};
 
     do1.save_device( buff.data() );
-    EXPECT_STREQ( "DO1={M=0, ST=0, P_DT=0},\n", buff.data() );
+    EXPECT_STREQ( "DO1={M=0, ST=0},\n", buff.data() );
 
     do1.set_cmd( "P_DT", 0, 100.1f );
     do1.save_device( buff.data() );
-    EXPECT_STREQ( "DO1={M=0, ST=0, P_DT=100.10},\n", buff.data() );
+    EXPECT_STREQ( "DO1={M=0, ST=0},\n", buff.data() );
     }
 
 
@@ -2121,7 +2118,7 @@ TEST( analog_output, save_device )
 
     AO01.save_device( buff.data() );
     EXPECT_STREQ( "AO1={M=0, V=0, E=0, M_EXP=1.0, S_DEV=0.2, "
-        "P_DT=0, P_MIN_V=0, P_MAX_V=0},\n",
+        "P_MIN_V=0, P_MAX_V=0},\n",
         buff.data() );
     }
 
@@ -2219,7 +2216,7 @@ TEST( DO_signal, DO_signal )
     DO_signal DO1( "DO1" );
 
     DO1.save_device( buff );
-    EXPECT_STREQ( "DO1={M=0, ST=0, P_DT=0},\n", buff );
+    EXPECT_STREQ( "DO1={M=0, ST=0},\n", buff );
     }
 
 TEST( DO_signal, get_type_name )
@@ -2236,7 +2233,7 @@ TEST( siren, siren )
     siren S1( "S1" );
 
     S1.save_device( buff );
-    EXPECT_STREQ( "S1={M=0, ST=0, P_DT=0},\n", buff );
+    EXPECT_STREQ( "S1={M=0, ST=0},\n", buff );
     }
 
 TEST( siren, get_type_name )
@@ -2253,7 +2250,7 @@ TEST( lamp, lamp )
     lamp L1( "L1" );
 
     L1.save_device( buff );
-    EXPECT_STREQ( "L1={M=0, ST=0, P_DT=0},\n", buff );
+    EXPECT_STREQ( "L1={M=0, ST=0},\n", buff );
     }
 
 TEST( lamp, get_type_name )
@@ -2758,13 +2755,7 @@ TEST( analog_valve, save_device )
     std::array <char, BUFF_SIZE> buff{};
 
     vc1.save_device( buff.data() );
-    EXPECT_STREQ( "VC1={M=0, ST=0, V=0, E=0, M_EXP=1.0, S_DEV=0.2, P_DT=0},\n",
-        buff.data() );
-
-    vc1.set_cmd( "P_DT", 0, 100.1f );
-    vc1.save_device( buff.data() );
-    EXPECT_STREQ( "VC1={M=0, ST=0, V=0, E=0, M_EXP=1.0, S_DEV=0.2, "
-        "P_DT=100.10},\n",
+    EXPECT_STREQ( "VC1={M=0, ST=0, V=0, E=0, M_EXP=1.0, S_DEV=0.2},\n",
         buff.data() );
     }
 
@@ -4153,9 +4144,8 @@ TEST( analog_valve_iolink, analog_valve_iolink )
     char buff[ BUFF_SIZE ] = { 0 };
     V1.save_device( buff );
     EXPECT_STREQ(
-        "V1={M=0, ST=0, V=0, NAMUR_ST=0, OPENED=0, CLOSED=1, BLINK=0, "
-        "P_DT=0, P_FB=1},\n",
-        buff );
+        "V1={M=0, ST=0, V=0, NAMUR_ST=0, OPENED=0, CLOSED=1, "
+        "BLINK=0, P_FB=1},\n", buff );
     }
 
 
@@ -6905,7 +6895,7 @@ TEST_F( iolink_dev_test, analog_valve_iolink_get_state_respects_P_FB )
     // Отключаем обратную связь (P_FB=0) — ошибки устройства игнорируются,
     // get_state() должен вернуть 1.
     VC1.set_par( static_cast<int>( analog_valve_iolink::PAR_CONSTANTS::P_FB ),
-        VC1.start_param_idx, 0.0f );
+        0, 0.0f );
     VC1.evaluate_io();
     EXPECT_EQ( VC1.get_state(), 1 );
 
@@ -6993,10 +6983,12 @@ class DO1_test : public ::testing::Test
 TEST_F( DO1_test, get_state_with_node_check_ok )
     {
     // Node is OK, should return channel value.
+    dev.evaluate_io();
     EXPECT_EQ( 1, dev.get_state() );
 
     // Set DO channel value to 0.
     *dev.DO_channels.char_write_values[ 0 ] = 0;
+    dev.evaluate_io();
 
     // Node is OK, should return channel value.
     EXPECT_EQ( 0, dev.get_state() );
@@ -7005,6 +6997,7 @@ TEST_F( DO1_test, get_state_with_node_check_ok )
 TEST_F( DO1_test, get_state_with_node_pp_mode )
     {
     node->status_register = 0x0010;  // PP mode active.
+    dev.evaluate_io();
 
     // Node in PP mode, should return error (-1).
     EXPECT_EQ( -1, dev.get_state() );
@@ -7013,15 +7006,17 @@ TEST_F( DO1_test, get_state_with_node_pp_mode )
 TEST_F( DO1_test, get_state_with_node_not_connected )
     {
     node->state = io_manager::io_node::ST_NO_CONNECT;
+    dev.evaluate_io();
 
-    // Node not connected, should return error (-1).
-    EXPECT_EQ( -1, dev.get_state() );
+    // Node not connected, should not return error (-1).
+    EXPECT_EQ( 1, dev.get_state() );
     }
 
 TEST_F( DO1_test, get_state_with_node_not_active )
     {
     node->is_active = false;  // Node not active.
+    dev.evaluate_io();
 
-    // Node not active, should return error (-1).
-    EXPECT_EQ( -1, dev.get_state() );
+    // Node not active, should not return error (-1).
+    EXPECT_EQ( 1, dev.get_state() );
     }

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -1615,11 +1615,17 @@ TEST( DO1, get_state )
 
     auto node = mngr.get_node( 0 );
     node->status_register = 0x0010; // PP mode.
+    DeltaMilliSecSubHooker::set_millisec( 0 );
     EXPECT_EQ( do1.get_state(), -1 );
 
     do1.set_cmd( "P_DT", 0, 1000.0f );
     EXPECT_EQ( do1.get_state(), 1 );
+    DeltaMilliSecSubHooker::set_millisec( 1001 );
 
+    EXPECT_EQ( node->status_register, 0x0010 );
+    EXPECT_EQ( do1.get_state(), -1 );
+
+    DeltaMilliSecSubHooker::set_default_time();
     io_manager::replace_instance( prev_mngr );
     G_PAC_INFO()->emulation_on();
 

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -2726,12 +2726,12 @@ TEST( analog_valve, save_device )
     std::array <char, BUFF_SIZE> buff{};
 
     vc1.save_device( buff.data() );
-    EXPECT_STREQ( "VC1={M=0, ST=1, V=0, E=0, M_EXP=1.0, S_DEV=0.2, P_DT=0},\n",
+    EXPECT_STREQ( "VC1={M=0, ST=0, V=0, E=0, M_EXP=1.0, S_DEV=0.2, P_DT=0},\n",
         buff.data() );
 
     vc1.set_cmd( "P_DT", 0, 100.1f );
     vc1.save_device( buff.data() );
-    EXPECT_STREQ( "VC1={M=0, ST=1, V=0, E=0, M_EXP=1.0, S_DEV=0.2, "
+    EXPECT_STREQ( "VC1={M=0, ST=0, V=0, E=0, M_EXP=1.0, S_DEV=0.2, "
         "P_DT=100.10},\n",
         buff.data() );
     }
@@ -2829,7 +2829,7 @@ TEST_F( analog_valve_test, io_modules_direct_on_off )
     {
     // По умолчанию 0%.
     EXPECT_FLOAT_EQ( 0.0f, VC1.get_value() );
-    EXPECT_EQ( 1, VC1.get_state() );
+    EXPECT_EQ( 0, VC1.get_state() );
 
     // direct_on -> 100%
     VC1.direct_on();
@@ -4114,7 +4114,7 @@ TEST( analog_valve_iolink, analog_valve_iolink )
     char buff[ BUFF_SIZE ] = { 0 };
     V1.save_device( buff );
     EXPECT_STREQ(
-        "V1={M=0, ST=1, V=0, NAMUR_ST=0, OPENED=0, CLOSED=1, BLINK=0, "
+        "V1={M=0, ST=0, V=0, NAMUR_ST=0, OPENED=0, CLOSED=1, BLINK=0, "
         "P_DT=0, P_FB=1},\n",
         buff );
     }

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -1659,10 +1659,6 @@ TEST( DO1, save_device )
 
     do1.save_device( buff.data() );
     EXPECT_STREQ( "DO1={M=0, ST=0},\n", buff.data() );
-
-    do1.set_cmd( "P_DT", 0, 100.1f );
-    do1.save_device( buff.data() );
-    EXPECT_STREQ( "DO1={M=0, ST=0},\n", buff.data() );
     }
 
 

--- a/test/device/PAC_dev_tests.cpp
+++ b/test/device/PAC_dev_tests.cpp
@@ -2161,25 +2161,30 @@ TEST( DI_signal, get_state )
 
     G_PAC_INFO()->emulation_off();
     DI1.init_and_alloc( 0, 1 );
+    DI1.evaluate_io();
     EXPECT_EQ( DI1.get_state(), 0 );
 
     *DI1.DI_channels.char_read_values[ 0 ] = 1;
+    DI1.evaluate_io();
     EXPECT_EQ( DI1.get_state(), 1 );
 
     *DI1.DI_channels.char_read_values[ 0 ] = 0;
     DI1.set_cmd( "P_DT", 0, 1000.0f );
+    DI1.evaluate_io();
     // Область чтения изменилась, но не прошло заданное время - состояние не
     // должно изменяться.
     EXPECT_EQ( DI1.get_state(), 1 );
 
     DeltaMilliSecSubHooker::set_millisec( 1010UL );
+    DI1.evaluate_io();
     // Прошло заданное время - состояние должно измениться.
     EXPECT_EQ( DI1.get_state(), 0 );
 
     // Область чтения не изменилась - состояние не должно изменяться.
+    DI1.evaluate_io();
     EXPECT_EQ( DI1.get_state(), 0 );
-    DeltaMilliSecSubHooker::set_default_time();
 
+    DeltaMilliSecSubHooker::set_default_time();
     G_PAC_INFO()->emulation_on();
     }
 
@@ -2854,21 +2859,25 @@ TEST_F( analog_valve_test, io_modules_direct_on_off )
 
     // direct_on -> 100%
     VC1.direct_on();
+    VC1.evaluate_io();
     EXPECT_FLOAT_EQ( 100.0f, VC1.get_value() );
     EXPECT_EQ( 1, VC1.get_state() );
 
     // direct_off -> 0%
     VC1.direct_off();
+    VC1.evaluate_io();
     EXPECT_FLOAT_EQ( 0.0f, VC1.get_value() );
     EXPECT_EQ( 0, VC1.get_state() );
 
     // direct_set_value -> произвольное значение
     VC1.direct_set_value( 37.5f );
+    VC1.evaluate_io();
     EXPECT_FLOAT_EQ( 37.5f, VC1.get_value() );
     EXPECT_EQ( 1, VC1.get_state() );
 
     // Повторное выключение
     VC1.direct_off();
+    VC1.evaluate_io();
     EXPECT_FLOAT_EQ( 0.0f, VC1.get_value() );
     EXPECT_EQ( 0, VC1.get_state() );
     }
@@ -2877,17 +2886,20 @@ TEST_F( analog_valve_test, io_modules_set_cmd_st_resets_value )
     {
     // Открыть клапан на 100% через set_cmd("V").
     VC1.set_cmd( "V", 0, 100.0 );
+    VC1.evaluate_io();
     EXPECT_FLOAT_EQ( 100.0f, VC1.get_value() );
     EXPECT_EQ( 1, VC1.get_state() );
 
     // Закрыть клапан через ST=0 -> значение должно сброситься в 0%.
     VC1.set_cmd( "ST", 0, 0.0 );
+    VC1.evaluate_io();
     EXPECT_FLOAT_EQ( 0.0f, VC1.get_value() );
     EXPECT_EQ( 0, VC1.get_state() );
 
     // Открыть клапан через ST=1 -> значение должно сброситься в 100%.
     VC1.set_cmd( "V", 0, 55.0 );
     VC1.set_cmd( "ST", 0, 1.0 );
+    VC1.evaluate_io();
     EXPECT_EQ( 1, VC1.get_state() );
     EXPECT_FLOAT_EQ( 100.0f, VC1.get_value() );
     }

--- a/test/device/ao_node_state_tests.cpp
+++ b/test/device/ao_node_state_tests.cpp
@@ -27,8 +27,8 @@ TEST( ao_node_state, analog_output_get_state_returns_error_on_bad_ao_node )
     EXPECT_EQ( 1, ao1.get_state() );
 
     ao1.set_par( 1, 0, 100.0f );
-    ao1.evaluate_io();
     node->status_register = 0x0010; // PP mode.
+    ao1.evaluate_io();    
     EXPECT_EQ( 1, ao1.get_state() );
 
     ao1.set_par( 1, 0, 0.0f );
@@ -63,16 +63,19 @@ TEST( ao_node_state, analog_valve_get_state_returns_error_on_bad_ao_node )
     vc1.direct_on();
     vc1.evaluate_io();
     EXPECT_EQ( 1, vc1.get_state() );
-
+    
+    DeltaMilliSecSubHooker::set_millisec( 0 );
     node->status_register = 0x0010; // PP mode.
-    vc1.set_par( 1, 0, 100.0f );
+    vc1.set_cmd( "P_DT", 0, 1000.0f );
     vc1.evaluate_io();
     EXPECT_EQ( 1, vc1.get_state() );
 
+    DeltaMilliSecSubHooker::set_millisec( 1001 );
     vc1.set_par( 1, 0, 0.0f );
     vc1.evaluate_io();
     EXPECT_EQ( -1, vc1.get_state() );
 
+    DeltaMilliSecSubHooker::set_default_time();
     G_PAC_INFO()->emulation_on();
     io_manager::replace_instance( prev_mngr );
     }

--- a/test/device/ao_node_state_tests.cpp
+++ b/test/device/ao_node_state_tests.cpp
@@ -25,7 +25,11 @@ TEST( ao_node_state, analog_output_get_state_returns_error_on_bad_ao_node )
     ao1.set_state( 1 );
     EXPECT_EQ( 1, ao1.get_state() );
 
+    ao1.set_par( 1, 0, 100.0f );
     node->status_register = 0x0010; // PP mode.
+    EXPECT_EQ( 1, ao1.get_state() );
+
+    ao1.set_par( 1, 0, 0.0f );
     EXPECT_EQ( -1, ao1.get_state() );
 
     G_PAC_INFO()->emulation_on();
@@ -57,6 +61,10 @@ TEST( ao_node_state, analog_valve_get_state_returns_error_on_bad_ao_node )
     EXPECT_EQ( 1, vc1.get_state() );
 
     node->status_register = 0x0010; // PP mode.
+    vc1.set_par( 1, 0, 100.0f );
+    EXPECT_EQ( 1, vc1.get_state() );
+
+    vc1.set_par( 1, 0, 0.0f );
     EXPECT_EQ( -1, vc1.get_state() );
 
     G_PAC_INFO()->emulation_on();

--- a/test/device/ao_node_state_tests.cpp
+++ b/test/device/ao_node_state_tests.cpp
@@ -28,10 +28,6 @@ TEST( ao_node_state, analog_output_get_state_returns_error_on_bad_ao_node )
 
     ao1.set_par( 1, 0, 100.0f );
     node->status_register = 0x0010; // PP mode.
-    ao1.evaluate_io();    
-    EXPECT_EQ( 1, ao1.get_state() );
-
-    ao1.set_par( 1, 0, 0.0f );
     ao1.evaluate_io();
     EXPECT_EQ( -1, ao1.get_state() );
 
@@ -64,13 +60,7 @@ TEST( ao_node_state, analog_valve_get_state_returns_error_on_bad_ao_node )
     vc1.evaluate_io();
     EXPECT_EQ( 1, vc1.get_state() );
     
-    DeltaMilliSecSubHooker::set_millisec( 0 );
     node->status_register = 0x0010; // PP mode.
-    vc1.set_cmd( "P_DT", 0, 1000.0f );
-    vc1.evaluate_io();
-    EXPECT_EQ( 1, vc1.get_state() );
-
-    DeltaMilliSecSubHooker::set_millisec( 1001 );
     vc1.set_par( 1, 0, 0.0f );
     vc1.evaluate_io();
     EXPECT_EQ( -1, vc1.get_state() );

--- a/test/device/ao_node_state_tests.cpp
+++ b/test/device/ao_node_state_tests.cpp
@@ -23,13 +23,16 @@ TEST( ao_node_state, analog_output_get_state_returns_error_on_bad_ao_node )
     node->status_register = 0;
 
     ao1.set_state( 1 );
+    ao1.evaluate_io();
     EXPECT_EQ( 1, ao1.get_state() );
 
     ao1.set_par( 1, 0, 100.0f );
+    ao1.evaluate_io();
     node->status_register = 0x0010; // PP mode.
     EXPECT_EQ( 1, ao1.get_state() );
 
     ao1.set_par( 1, 0, 0.0f );
+    ao1.evaluate_io();
     EXPECT_EQ( -1, ao1.get_state() );
 
     G_PAC_INFO()->emulation_on();
@@ -58,13 +61,16 @@ TEST( ao_node_state, analog_valve_get_state_returns_error_on_bad_ao_node )
     node->status_register = 0;
 
     vc1.direct_on();
+    vc1.evaluate_io();
     EXPECT_EQ( 1, vc1.get_state() );
 
     node->status_register = 0x0010; // PP mode.
     vc1.set_par( 1, 0, 100.0f );
+    vc1.evaluate_io();
     EXPECT_EQ( 1, vc1.get_state() );
 
     vc1.set_par( 1, 0, 0.0f );
+    vc1.evaluate_io();
     EXPECT_EQ( -1, vc1.get_state() );
 
     G_PAC_INFO()->emulation_on();


### PR DESCRIPTION
Connected with #1184.

Sets error only if `I/O` node goes to `PP` mode.