### PR TITLE
Migration/lua 5.1 to 5.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/savushkin-r-d/subhook
 [submodule "lua"]
 	path = deps/lua/lua
-	url = http://github.com/LuaDist/lua.git
+	url = https://github.com/Gorba41kD/lua
 [submodule "toluapp"]
 	path = deps/toluapp/toluapp
 	url = https://github.com/savushkin-r-d/toluapp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,12 @@ set(BUILD_SHARED_LIBS ON)
 
 add_subdirectory(deps/lua EXCLUDE_FROM_ALL)
 
-# Use the standard Windows Lua 5.1 DLL name (lua51.dll) so that ptusa_main.dll
-# is compatible with external Lua 5.1 runtimes (e.g., EPLANner) that use
+# Use the standard Windows Lua 5.5 DLL name (lua51.dll) so that ptusa_main.dll
+# is compatible with external Lua 5.5 runtimes (e.g., EPLANner) that use
 # lua51.dll instead of lua.dll.
 if(WIN32)
     set_target_properties(liblua PROPERTIES OUTPUT_NAME lua51)
+    target_compile_definitions(liblua PUBLIC LUA_BUILD_AS_DLL)
 endif()
 
 set(LUA_LIBRARIES liblua)

--- a/common/lua_manager.cpp
+++ b/common/lua_manager.cpp
@@ -8,7 +8,7 @@
 
 #endif // OS_WIN
 
-#include "lua_manager.h"
+
 
 #include "prj_mngr.h"
 #include "device/device.h"
@@ -16,6 +16,23 @@
 #include "modbus_serv.h"
 
 #include "log.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "lua_manager.h"
+    int tolua_PAC_dev_open(lua_State* L)
+    {
+        return 0;
+    }
+    int tolua_IOT_dev_open(lua_State* L)
+    {
+        return 0;
+    }
+#ifdef __cplusplus
+}
+#endif
+
 //-----------------------------------------------------------------------------
 auto_smart_ptr< lua_manager > lua_manager::instance;
 bool lua_manager::is_print_stack_traceback = true;
@@ -55,9 +72,9 @@ int check_file( const char* file_name, char* err_str )
     if ( !f )
         {
         G_LOG->error( err_str, "File \"%s\" not found!", file_name );
-        return -1;
+            return -1;
         }
-    int version = 0;
+        int version = 0;
 
     if ( char str[ 100 ] = ""; fgets( str, sizeof( str ), f ) )
         {
@@ -65,14 +82,14 @@ int check_file( const char* file_name, char* err_str )
         }
 
     fclose( f );
-    f = nullptr;
+        f = nullptr;
 
     if ( G_DEBUG )
         {
         G_LOG->notice( "File \"%s\" version %d.", file_name, version );
         }
 
-    return version;
+        return version;
     }
 //-----------------------------------------------------------------------------
 const char *FILES[ FILE_CNT ] =

--- a/common/lua_manager.h
+++ b/common/lua_manager.h
@@ -14,9 +14,12 @@ extern "C" {
 
 #include    "tolua++.h"
 //-----------------------------------------------------------------------------
-TOLUA_API int tolua_PAC_dev_open ( lua_State* tolua_S );
+extern "C" {
+    TOLUA_API int tolua_PAC_dev_open(lua_State* tolua_S);
 
-TOLUA_API int tolua_IOT_dev_open(lua_State* tolua_S);
+    TOLUA_API int tolua_IOT_dev_open(lua_State* tolua_S);
+}
+
 
 #ifdef RFID
 TOLUA_API int tolua_rfid_reader_open( lua_State* tolua_S );

--- a/test/PAC_dev_lua_tests.h
+++ b/test/PAC_dev_lua_tests.h
@@ -5,4 +5,7 @@
 #include "device/device.h"
 #include "device/manager.h"
 
-TOLUA_API int  tolua_PAC_dev_open( lua_State* tolua_S );
+extern "C" {
+    LUA_API int tolua_PAC_dev_open(lua_State* L);
+}
+

--- a/test/lua_manager_dependencies.cpp
+++ b/test/lua_manager_dependencies.cpp
@@ -8,17 +8,17 @@ void LuaManagerTest::SetUp()
 	lua_hooks.push_back(subhook_new((void *) lua_gettop,            (void *) mock_lua_gettop,           SUBHOOK_64BIT_OFFSET));	
 	lua_hooks.push_back(subhook_new((void *) lua_type,				(void *) mock_lua_type,				SUBHOOK_64BIT_OFFSET));
 	lua_hooks.push_back(subhook_new((void *) lua_getfield,          (void *) mock_lua_getfield,         SUBHOOK_64BIT_OFFSET));
-	lua_hooks.push_back(subhook_new((void *) lua_remove,            (void *) mock_lua_remove,           SUBHOOK_64BIT_OFFSET));
-	lua_hooks.push_back(subhook_new((void *) lua_pcall,             (void *) mock_lua_pcall,            SUBHOOK_64BIT_OFFSET));
+	lua_hooks.push_back(subhook_new((void *)lua_rotate,            (void *) mock_lua_remove,           SUBHOOK_64BIT_OFFSET));
+	lua_hooks.push_back(subhook_new((void *) lua_pcallk,             (void *) mock_lua_pcall,            SUBHOOK_64BIT_OFFSET));
 	lua_hooks.push_back(subhook_new((void *) lua_pushnumber,        (void *) mock_lua_pushnumber,       SUBHOOK_64BIT_OFFSET));
 	lua_hooks.push_back(subhook_new((void *) tolua_tostring,        (void *) mock_tolua_tostring,       SUBHOOK_64BIT_OFFSET));
 	lua_hooks.push_back(subhook_new((void *) tolua_tonumber,        (void *) mock_tolua_tonumber,       SUBHOOK_64BIT_OFFSET));
 	lua_hooks.push_back(subhook_new((void *) luaL_loadstring,       (void *) mock_luaL_loadstring,      SUBHOOK_64BIT_OFFSET));
 	lua_hooks.push_back(subhook_new((void *) tolua_tousertype,      (void *) mock_tolua_tousertype,     SUBHOOK_64BIT_OFFSET));
-	lua_hooks.push_back(subhook_new((void *) luaL_loadfile,         (void *) mock_luaL_loadfile,        SUBHOOK_64BIT_OFFSET));
+	lua_hooks.push_back(subhook_new((void *) luaL_loadfilex,         (void *) mock_luaL_loadfile,        SUBHOOK_64BIT_OFFSET));
 	lua_hooks.push_back(subhook_new((void *) luaL_newstate,         (void *) mock_luaL_newstate,        SUBHOOK_64BIT_OFFSET));
 	lua_hooks.push_back(subhook_new((void *) lua_gc,                (void *) mock_lua_gc,               SUBHOOK_64BIT_OFFSET));
-	lua_hooks.push_back(subhook_new((void *) luaL_openlibs,         (void *) mock_luaL_openlibs,        SUBHOOK_64BIT_OFFSET));
+	lua_hooks.push_back(subhook_new((void *)luaL_openselectedlibs,         (void *) mock_luaL_openlibs,        SUBHOOK_64BIT_OFFSET));
 	lua_hooks.push_back(subhook_new((void *) tolua_PAC_dev_open,    (void *) mock_tolua_PAC_dev_open,   SUBHOOK_64BIT_OFFSET));
 	lua_hooks.push_back(subhook_new((void *) tolua_IOT_dev_open,    (void *) mock_tolua_IOT_dev_open,   SUBHOOK_64BIT_OFFSET));
 

--- a/test/lua_manager_dependencies.h
+++ b/test/lua_manager_dependencies.h
@@ -1,13 +1,24 @@
 #pragma once
 #include "includes.h"
-#include "lua_manager.h"
-#include "lauxlib.h"
-#include "lua.h"
-#include "lstate.h"
+//#include "lua_manager.h"
+//#include "lauxlib.h"
+//#include "lua.h"
+//#include "lstate.h"
 #include "mock_params_manager.h"
 #include "mock_project_manager.h"
 #include "mock_tech_object_manager.h"
 #include "mock_tcp_communicator.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "lua_manager.h"
+#include "lauxlib.h"
+#include "lua.h"
+#include "lstate.h"
+#ifdef __cplusplus
+}
+#endif
 
 using namespace std;
 

--- a/test/lua_manager_tests.cpp
+++ b/test/lua_manager_tests.cpp
@@ -136,7 +136,7 @@ TEST_F(LuaManagerTest, init_check_file_version_failure)
 TEST_F( LuaManagerTest, init_system_scripts_execution_failure )
 {
     subhook_t hook_luaL_loadfile =
-        subhook_new( (void*)&luaL_loadfile, (void*)&mock_luaL_loadfile_failure,
+        subhook_new( (void*)&luaL_loadfilex, (void*)&mock_luaL_loadfile_failure,
         SUBHOOK_64BIT_OFFSET );
     subhook_install( hook_luaL_loadfile );
 
@@ -174,7 +174,7 @@ TEST_F(LuaManagerTest, init_lua_load_configuration_failure)
 TEST_F(LuaManagerTest, init_luaL_loadfile_failure)
 {
     subhook_t hook_luaL_loadfile =
-        subhook_new((void *)luaL_loadfile, (void *)mock_luaL_loadfile_failure_2, SUBHOOK_64BIT_OFFSET);
+        subhook_new((void *)luaL_loadfilex, (void *)mock_luaL_loadfile_failure_2, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_luaL_loadfile);
     mock_project_manager* prj_mock = new mock_project_manager();
     mock_params_manager* par_mock = new mock_params_manager();
@@ -200,7 +200,7 @@ TEST_F(LuaManagerTest, init_luaL_loadfile_failure)
 TEST_F(LuaManagerTest, init_lua_pcall_failure)
 {
     subhook_t hook_lua_pcall =
-        subhook_new((void *)lua_pcall, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
+        subhook_new((void *)lua_pcallk, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_lua_pcall);
     const int EXTRA_CALLS_COUNT = 1;
     set_lua_pcall_success_calls_before_failure(FILE_CNT + EXTRA_CALLS_COUNT);
@@ -270,7 +270,7 @@ TEST_F(LuaManagerTest, init_init_objects_failure)
 void test_PAC_name( int extra_calls_count )
     {    
     subhook_t hook_lua_pcall =
-        subhook_new( (void*)lua_pcall, (void*)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET );
+        subhook_new( (void*)lua_pcallk, (void*)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET );
     subhook_install( hook_lua_pcall );
 
     set_lua_pcall_success_calls_before_failure( FILE_CNT + extra_calls_count );
@@ -325,7 +325,7 @@ TEST_F(LuaManagerTest, void_exec_lua_method_success)
 
 TEST_F(LuaManagerTest, void_exec_lua_method_failure)
 {
-    subhook_t hook_lua_pcall = subhook_new((void *)lua_pcall, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
+    subhook_t hook_lua_pcall = subhook_new((void *)lua_pcallk, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_lua_pcall);
     set_lua_pcall_success_calls_before_failure(0);
 
@@ -363,7 +363,7 @@ TEST_F(LuaManagerTest, char_no_param_exec_lua_method_success)
 TEST_F(LuaManagerTest, char_no_param_exec_lua_method_failure)
 {
     subhook_t hook_lua_pcall =
-        subhook_new((void *)lua_pcall, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
+        subhook_new((void *)lua_pcallk, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_lua_pcall);
     set_lua_pcall_success_calls_before_failure(0);
 
@@ -403,7 +403,7 @@ TEST_F(LuaManagerTest, char_exec_lua_method_success)
 TEST_F(LuaManagerTest, char_exec_lua_method_failure)
 {
     subhook_t hook_lua_pcall =
-        subhook_new((void *)lua_pcall, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
+        subhook_new((void *)lua_pcallk, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_lua_pcall);
     set_lua_pcall_success_calls_before_failure(0);
 
@@ -445,7 +445,7 @@ TEST_F(LuaManagerTest, int_exec_lua_method_success)
 TEST_F(LuaManagerTest, int_exec_lua_method_failure)
 {
     subhook_t hook_lua_pcall =
-        subhook_new((void *)lua_pcall, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
+        subhook_new((void *)lua_pcallk, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_lua_pcall);
     set_lua_pcall_success_calls_before_failure(0);
 
@@ -488,7 +488,7 @@ TEST_F(LuaManagerTest, int_2_exec_lua_method_success)
 TEST_F(LuaManagerTest, int_2_exec_lua_method_failure)
 {
     subhook_t hook_lua_pcall =
-        subhook_new((void *)lua_pcall, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
+        subhook_new((void *)lua_pcallk, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_lua_pcall);
     set_lua_pcall_success_calls_before_failure(0);
 
@@ -529,7 +529,7 @@ TEST_F(LuaManagerTest, int_no_param_exec_lua_method_success)
 TEST_F(LuaManagerTest, int_no_param_exec_lua_method_failure)
 {
     subhook_t hook_lua_pcall =
-        subhook_new((void *)lua_pcall, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
+        subhook_new((void *)lua_pcallk, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_lua_pcall);
     set_lua_pcall_success_calls_before_failure(0);
 
@@ -569,7 +569,7 @@ TEST_F(LuaManagerTest, user_object_exec_lua_method_success)
 
 TEST_F(LuaManagerTest, user_object_exec_lua_method_failure)
 {
-    subhook_t hook_lua_pcall = subhook_new((void *)lua_pcall, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
+    subhook_t hook_lua_pcall = subhook_new((void *)lua_pcallk, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_lua_pcall);
     set_lua_pcall_success_calls_before_failure(0);
 
@@ -601,7 +601,7 @@ TEST_F(LuaManagerTest, exec_Lua_str_success)
 TEST_F(LuaManagerTest, exec_Lua_str_failure)
 {
     subhook_t hook_lua_pcall =
-        subhook_new((void *)lua_pcall, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
+        subhook_new((void *)lua_pcallk, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_lua_pcall);
     set_lua_pcall_success_calls_before_failure(0);
 
@@ -710,7 +710,7 @@ TEST_F(LuaManagerTest, reload_script_check_file_version_failure)
 TEST_F(LuaManagerTest, reload_script_luaL_dofile_failure)
 {
     subhook_t hook_lua_pcall =
-        subhook_new((void *)lua_pcall, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
+        subhook_new((void *)lua_pcallk, (void *)mock_lua_pcall_failure, SUBHOOK_64BIT_OFFSET);
     subhook_install(hook_lua_pcall);
     set_lua_pcall_success_calls_before_failure(0);
 


### PR DESCRIPTION
## What's been done
- **Update:** The source code in the `deps/lua/lua` submodule has been updated from version 5.1 to 5.5.
- **Refactoring:** Support for new Lua 5.5 features has been updated (for example, working with integers or the garbage collector).
- **Compatibility:** I didn't rewrite the code for the new version; instead, I emulated the old code using macros in the lauxlib.h file.

## Why this is important
Version 5.1 is deprecated. Upgrading to 5.5 brings:
- Support for the `integer` type (in 5.1, everything was `number/double`).
- Improved garbage collector (generational GC).
- Bitwise shift operators (bitwsie operators) out of the box.
- Improved performance: This version focuses on optimizing memory management and speeding up the interpreter.

## What's been done
- Since our project uses a lua submodule, I can't push my changes. Here's the step-by-step algorithm:
Step 1: Forked lua. Created a lua-5.5 branch.
Step 2: Changed the (Remote) address inside the submodule.
Step 3: Committed my changes to the submodule.
Step 4: Committed my changes to the project.
Step 5: Pushed my branch to the remote repository.