### PR TITLE
[config][cmake] Fixes `PLCnext` build by making `lua` dependency conditional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,10 @@ elseif(WIN32)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
 endif()
 
-add_dependencies(libptusa_main lua)
+if(NOT ARP_DEVICE)
+    add_dependencies(libptusa_main lua)
+endif()
+
 add_dependencies(lua lfs luasystem term_core luassert_copy luasql_odbc)
 
 if(MSVC)


### PR DESCRIPTION
Prevents `libptusa_main` from depending on the `lua` target when `ARP_DEVICE` is defined, ensuring compatibility with the PLCnext build environment.
