### PR TITLE
Sets `OPC UA` server iteration to non-blocking

### DIFF
--- a/PAC/common/OPCUAServer.cpp
+++ b/PAC/common/OPCUAServer.cpp
@@ -212,6 +212,7 @@ void OPCUA_server::shutdown()
         server = nullptr;
 
         is_dev_objects_created = false;
+        is_PAC_info_created = false;
         }
     }
 

--- a/PAC/common/OPCUAServer.cpp
+++ b/PAC/common/OPCUAServer.cpp
@@ -217,7 +217,7 @@ void OPCUA_server::shutdown()
 
 void OPCUA_server::evaluate()
     {
-    if ( server ) UA_Server_run_iterate( server, true );
+    if ( server ) UA_Server_run_iterate( server, false );
     }
 
 UA_StatusCode OPCUA_server::read_state( UA_Server*, const UA_NodeId*, void*,

--- a/test/OPCUAServer_tests.cpp
+++ b/test/OPCUAServer_tests.cpp
@@ -4,7 +4,16 @@
 
 using namespace ::testing;
 
-TEST( OPCUA_server, evaluate_non_blocking )
+class OPCUA_server_test : public Test
+    {
+    protected:
+        void TearDown() override
+            {
+            G_OPCUA_SERVER.shutdown();
+            }
+    };
+
+TEST_F( OPCUA_server_test, evaluate_non_blocking )
     {
     auto res = G_OPCUA_SERVER.init_all_and_start();
     ASSERT_EQ( UA_STATUSCODE_GOOD, res );
@@ -19,8 +28,6 @@ TEST( OPCUA_server, evaluate_non_blocking )
         std::chrono::steady_clock::now() - start );
 
     EXPECT_LT( elapsed.count(), 1000 );
-
-    G_OPCUA_SERVER.shutdown();
     }
 
 TEST( OPCUA_server, evaluate )

--- a/test/OPCUAServer_tests.cpp
+++ b/test/OPCUAServer_tests.cpp
@@ -1,7 +1,27 @@
 #include "OPCUAServer_tests.h"
 #include "g_errors.h"
+#include <chrono>
 
 using namespace ::testing;
+
+TEST( OPCUA_server, evaluate_non_blocking )
+    {
+    auto res = G_OPCUA_SERVER.init_all_and_start();
+    ASSERT_EQ( UA_STATUSCODE_GOOD, res );
+
+    constexpr int ITERATIONS = 200;
+    const auto start = std::chrono::steady_clock::now();
+    for ( int i = 0; i < ITERATIONS; ++i )
+        {
+        G_OPCUA_SERVER.evaluate();
+        }
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start );
+
+    EXPECT_LT( elapsed.count(), 1000 );
+
+    G_OPCUA_SERVER.shutdown();
+    }
 
 TEST( OPCUA_server, evaluate )
     {    
@@ -130,7 +150,7 @@ TEST( OPCUA_server, evaluate )
     EXPECT_EQ( 10, *state );
     UA_Variant_clear( &out );
     // Вызывать UA_Variant_clear( &val ); не надо, так как значение храниться в
-    // локальной переменной new_state.
+    // локальной переменной new_state;
 
 
     UA_Float new_value = 100.f;

--- a/test/OPCUAServer_tests.cpp
+++ b/test/OPCUAServer_tests.cpp
@@ -9,9 +9,9 @@ TEST( OPCUA_server, evaluate_non_blocking )
     auto res = G_OPCUA_SERVER.init_all_and_start();
     ASSERT_EQ( UA_STATUSCODE_GOOD, res );
 
-    constexpr int ITERATIONS = 200;
+    constexpr auto ITERATIONS = 200;
     const auto start = std::chrono::steady_clock::now();
-    for ( int i = 0; i < ITERATIONS; ++i )
+    for ( auto i = 0; i < ITERATIONS; ++i )
         {
         G_OPCUA_SERVER.evaluate();
         }
@@ -150,7 +150,7 @@ TEST( OPCUA_server, evaluate )
     EXPECT_EQ( 10, *state );
     UA_Variant_clear( &out );
     // Вызывать UA_Variant_clear( &val ); не надо, так как значение храниться в
-    // локальной переменной new_state;
+    // локальной переменной new_state.
 
 
     UA_Float new_value = 100.f;


### PR DESCRIPTION
Updates the `UA_Server_run_iterate` call to use non-blocking mode by setting the `waitInternal` parameter to false. This ensures that the OPC UA server evaluation does not stall the main execution loop.
