### PR TITLE
[cmake] Fixes 'ctest' configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,7 +531,7 @@ set(TCP_SOCKET_LOCKED_FILTER
 	"tcp_communicator.recvtimeout:"
     "device_communicator.write_devices_states_service:"
     "pp_mode_alarm.pp_mode_activation_deactivation:"
-    "pp_mode_alarm.disconnect_no_alarm:"
+    "pp_mode_alarm.e_communicate:"
     "main_cycle.main_cycle:"
 	"PAC_info.set_cmd:"
 	"LuaManagerTest.init_success:"


### PR DESCRIPTION
Replaces the obsolete `pp_mode_alarm.disconnect_no_alarm` with `pp_mode_alarm.e_communicate`. This aligns the filter with current `PP mode` alarm handling and test configurations.
