### PR TITLE
[fix] Enable unsafe `PR` checkout in CI workflows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -102,7 +102,7 @@ jobs:
         #
         # Default: false
         submodules: 'recursive'
-        allow-unsafe-pr-checkout: true'
+        allow-unsafe-pr-checkout: 'true'
 
     - name: Download Ninja and CMake
       shell: cmake -P {0}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -102,6 +102,7 @@ jobs:
         #
         # Default: false
         submodules: 'recursive'
+        allow-unsafe-pr-checkout: true'
 
     - name: Download Ninja and CMake
       shell: cmake -P {0}

--- a/.github/workflows/sonar_build.yml
+++ b/.github/workflows/sonar_build.yml
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: 'recursive'
           ref: ${{ github.event.pull_request.head.sha }}
-          allow-unsafe-pr-checkout: true'
+          allow-unsafe-pr-checkout: 'true'
 
       # Disable man-db cache. Install unixodbc-dev.
       - name: Install unixodbc-dev

--- a/.github/workflows/sonar_build.yml
+++ b/.github/workflows/sonar_build.yml
@@ -59,6 +59,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: 'recursive'
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true'
 
       # Disable man-db cache. Install unixodbc-dev.
       - name: Install unixodbc-dev


### PR DESCRIPTION
This setting is required for GitHub Actions workflows to correctly check out, build, and analyze code from pull requests originating from forks. The default behavior of `actions/checkout` prevents this for security reasons, causing workflow failures for external contributions (https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target).
