### PR TITLE
Exclude `demo_projects` and `deps` from `SonarQube` analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,5 +8,5 @@ sonar.projectVersion=3.0
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 #Exclude buid directory, sonar directory, auto generated files (by tolua++)
-sonar.exclusions=build/**,build_wrapper_output_directory/**,PAC/common/PAC_dev_lua.cpp,PAC/common/OPCUA_tolua.cpp,PAC/IoT/IOT_dev_lua.cpp,PAC/common/toloa++/pkg/**
+sonar.exclusions=build/**,build_wrapper_output_directory/**,PAC/common/PAC_dev_lua.cpp,PAC/common/OPCUA_tolua.cpp,PAC/IoT/IOT_dev_lua.cpp,PAC/common/toloa++/pkg/**,demo_projects/**,deps/**
 sonar.coverage.exclusions=test/**


### PR DESCRIPTION
These directories typically contain example code or third-party dependencies, which should not contribute to the project's quality metrics and unnecessarily increase analysis time.
