### PR TITLE
[fix] Disable `Curses` for `Lua` dependency build

### DIFF
--- a/deps/lua/CMakeLists.txt
+++ b/deps/lua/CMakeLists.txt
@@ -4,4 +4,6 @@ endif()
 
 set(SKIP_TESTING TRUE)
 
+set(LUA_USE_CURSES OFF)
+
 add_subdirectory(lua)


### PR DESCRIPTION
Disables the Curses library during the Lua build process to prevent potential build issues and unnecessary linking, as Curses functionality is not required for this project.
Fix error:
```sh
./ptusa_main: error while loading shared libraries: libncurses.so.5: cannot open shared object file: No such file or directory
```